### PR TITLE
로그 모듈 추가

### DIFF
--- a/PyeonHaeng-iOS.xcodeproj/project.pbxproj
+++ b/PyeonHaeng-iOS.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		BA0564092B6248EA003D6DC7 /* HomeAPI in Frameworks */ = {isa = PBXBuildFile; productRef = BA0564082B6248EA003D6DC7 /* HomeAPI */; };
 		BA05640B2B6248EA003D6DC7 /* HomeAPISupport in Frameworks */ = {isa = PBXBuildFile; productRef = BA05640A2B6248EA003D6DC7 /* HomeAPISupport */; };
 		BA05640D2B6248EA003D6DC7 /* Network in Frameworks */ = {isa = PBXBuildFile; productRef = BA05640C2B6248EA003D6DC7 /* Network */; };
+		BA0623D82B68E51400A0A3B2 /* Log in Frameworks */ = {isa = PBXBuildFile; productRef = BA0623D72B68E51400A0A3B2 /* Log */; };
 		BA28F17C2B6155450052855E /* PyeonHaeng_iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA28F17B2B6155450052855E /* PyeonHaeng_iOSTests.swift */; };
 		BA28F1852B6155810052855E /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA28F1842B6155810052855E /* OnboardingView.swift */; };
 		BA28F1882B6155910052855E /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA28F1872B6155910052855E /* HomeView.swift */; };
@@ -104,6 +105,7 @@
 			files = (
 				BA05640D2B6248EA003D6DC7 /* Network in Frameworks */,
 				BA05640B2B6248EA003D6DC7 /* HomeAPISupport in Frameworks */,
+				BA0623D82B68E51400A0A3B2 /* Log in Frameworks */,
 				BA0564092B6248EA003D6DC7 /* HomeAPI in Frameworks */,
 				BAB569612B639F3000D1E0F9 /* DesignSystem in Frameworks */,
 			);
@@ -339,6 +341,7 @@
 				BA05640A2B6248EA003D6DC7 /* HomeAPISupport */,
 				BA05640C2B6248EA003D6DC7 /* Network */,
 				BAB569602B639F3000D1E0F9 /* DesignSystem */,
+				BA0623D72B68E51400A0A3B2 /* Log */,
 			);
 			productName = "PyeonHaeng-iOS";
 			productReference = BAA4D9A92B5A1795005999F8 /* PyeonHaeng-iOS.app */;
@@ -766,6 +769,10 @@
 		BA05640C2B6248EA003D6DC7 /* Network */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Network;
+		};
+		BA0623D72B68E51400A0A3B2 /* Log */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Log;
 		};
 		BAB569602B639F3000D1E0F9 /* DesignSystem */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Shared/Package.swift
+++ b/Shared/Package.swift
@@ -11,11 +11,16 @@ let package = Package(
       name: "DesignSystem",
       targets: ["DesignSystem"]
     ),
+    .library(
+      name: "Log",
+      targets: ["Log"]
+    ),
   ],
   targets: [
     .target(
       name: "DesignSystem",
       resources: [.process("Resources")]
     ),
+    .target(name: "Log"),
   ]
 )

--- a/Shared/Sources/Log/Log.swift
+++ b/Shared/Sources/Log/Log.swift
@@ -14,19 +14,18 @@ public enum Log {
   /// Log를 생성합니다.
   /// - Parameter category: Log를 구분하는 Category
   public static func make(_ context: some CustomStringConvertible, with logger: Logger, at level: Level) {
-    let message = context.description
     #if DEBUG
       switch level {
-      case .notice:
-        logger.notice("\(message)")
       case .debug:
-        logger.debug("\(message)")
+        logger.debug("\(context.description)")
       case .info:
-        logger.info("\(message)")
+        logger.info("\(context.description)")
+      case .notice:
+        logger.notice("\(context.description)")
       case .warning:
-        logger.warning("\(message)")
+        logger.warning("\(context.description)")
       case .fault:
-        logger.fault("\(message)")
+        logger.fault("\(context.description)")
       }
     #endif
   }
@@ -36,14 +35,18 @@ public enum Log {
 
 public extension Log {
   enum Level {
-    /// Writes a message to the log using the default log type.
-    case notice
     /// Writes a debug message to the log.
     case debug
+
     /// Writes an informative message to the log.
     case info
+
+    /// Writes a message to the log using the default log type.
+    case notice
+
     /// Writes information about a warning to the log.
     case warning
+
     /// Writes a message to the log about a bug that occurs when your app executes.
     case fault
   }

--- a/Shared/Sources/Log/Log.swift
+++ b/Shared/Sources/Log/Log.swift
@@ -1,0 +1,65 @@
+//
+//  Log.swift
+//
+//
+//  Created by 홍승현 on 1/30/24.
+//
+
+import OSLog
+
+// MARK: - Log
+
+/// 로그
+public enum Log {
+  /// Log를 생성합니다.
+  /// - Parameter category: Log를 구분하는 Category
+  public static func make(_ context: some CustomStringConvertible, with logger: Logger, at level: Level) {
+    let message = context.description
+    #if DEBUG
+      switch level {
+      case .notice:
+        logger.notice("\(message)")
+      case .debug:
+        logger.debug("\(message)")
+      case .info:
+        logger.info("\(message)")
+      case .warning:
+        logger.warning("\(message)")
+      case .fault:
+        logger.fault("\(message)")
+      }
+    #endif
+  }
+}
+
+// MARK: Log.Level
+
+public extension Log {
+  enum Level {
+    /// Writes a message to the log using the default log type.
+    case notice
+    /// Writes a debug message to the log.
+    case debug
+    /// Writes an informative message to the log.
+    case info
+    /// Writes information about a warning to the log.
+    case warning
+    /// Writes a message to the log about a bug that occurs when your app executes.
+    case fault
+  }
+}
+
+public extension Logger {
+  /// 네트워크 로그를 작성할 때 사용합니다.
+  static let network = Logger(subsystem: .bundleIdentifier, category: "network")
+
+  /// 뷰에 관한 로그를 작성할 때 사용합니다.
+  static let view = Logger(subsystem: .bundleIdentifier, category: "view")
+
+  /// 뷰모델에 관한 로그를 작성할 때 사용합니다.
+  static let viewModel = Logger(subsystem: .bundleIdentifier, category: "viewModel")
+}
+
+private extension String {
+  static let bundleIdentifier: String = Bundle.main.bundleIdentifier ?? "None"
+}


### PR DESCRIPTION
## Screenshots 📸

|로그 기능 화면|
|:-:|
|<img width="1072" alt="image" src="https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/73345bdc-6c1d-4f4f-9577-a3cf008e92cd">|

<br/><br/>

## 고민, 과정, 근거 💬

`Log.make(_:with:at:)`을 추가하였습니다. `Network`, `View`, `ViewModel`과 관련한 로그를 지원합니다. 이 이외에 추가적으로 로깅을 하고 싶다면 `public extension Logger` 파트에 직접 로거를 추가하시면 됩니다!

<br/><br/>

---

- Closed: #23
