### PR TITLE
[Home] Mock JSON으로 제품 리스트 가져오는 흐름 구현

### DIFF
--- a/APIService/Package.swift
+++ b/APIService/Package.swift
@@ -1,5 +1,4 @@
 // swift-tools-version: 5.9
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
@@ -18,12 +17,14 @@ let package = Package(
   ],
   dependencies: [
     .package(path: "../Core"),
+    .package(path: "../Entity"),
   ],
   targets: [
     .target(
       name: "HomeAPI",
       dependencies: [
         .product(name: "Network", package: "Core"),
+        .product(name: "Entity", package: "Entity"),
       ]
     ),
     .target(

--- a/APIService/Sources/HomeAPI/HomeEndPoint.swift
+++ b/APIService/Sources/HomeAPI/HomeEndPoint.swift
@@ -9,11 +9,11 @@ import Foundation
 import Network
 
 struct HomeEndPoint: EndPoint {
-  var method: HTTPMethod
+  let method: HTTPMethod = .get
 
-  var path: String
+  let path: String = "v2/products"
 
-  var parameters: Network.HTTPParameter
+  let parameters: HTTPParameter = .plain
 
-  var headers: [String: String]
+  let headers: [String: String] = ["Content-Type": "application/json"]
 }

--- a/APIService/Sources/HomeAPI/HomeService.swift
+++ b/APIService/Sources/HomeAPI/HomeService.swift
@@ -37,6 +37,7 @@ extension HomeService: HomeServiceRepresentable {
 private extension Product {
   init(dto: ProductResponse) {
     self.init(
+      id: dto.id,
       imageURL: dto.imageURL,
       price: dto.price,
       name: dto.name,

--- a/APIService/Sources/HomeAPI/HomeService.swift
+++ b/APIService/Sources/HomeAPI/HomeService.swift
@@ -1,0 +1,47 @@
+//
+//  HomeService.swift
+//
+//
+//  Created by 홍승현 on 1/31/24.
+//
+
+import Entity
+import Foundation
+import Network
+
+// MARK: - HomeServiceRepresentable
+
+public protocol HomeServiceRepresentable {
+  func fetchProductList() async throws -> [Product]
+}
+
+// MARK: - HomeService
+
+public struct HomeService {
+  private let network: Networking
+
+  public init(network: Networking) {
+    self.network = network
+  }
+}
+
+// MARK: HomeServiceRepresentable
+
+extension HomeService: HomeServiceRepresentable {
+  public func fetchProductList() async throws -> [Product] {
+    let products: [ProductResponse] = try await network.request(with: HomeEndPoint())
+    return products.map(Product.init)
+  }
+}
+
+private extension Product {
+  init(dto: ProductResponse) {
+    self.init(
+      imageURL: dto.imageURL,
+      price: dto.price,
+      name: dto.name,
+      promotion: dto.promotion,
+      convenienceStore: dto.convenienceStore
+    )
+  }
+}

--- a/APIService/Sources/HomeAPI/Requests/ProductRequest.swift
+++ b/APIService/Sources/HomeAPI/Requests/ProductRequest.swift
@@ -1,0 +1,17 @@
+//
+//  ProductRequest.swift
+//
+//
+//  Created by 홍승현 on 1/31/24.
+//
+
+import Entity
+import Foundation
+
+public struct ProductRequest: Encodable {
+  public let store: ConvenienceStore
+  public let promotion: Promotion
+  public let order: Order
+  public let pageSize: Int
+  public let offset: Int
+}

--- a/APIService/Sources/HomeAPI/Responses/ProductResponse.swift
+++ b/APIService/Sources/HomeAPI/Responses/ProductResponse.swift
@@ -5,12 +5,21 @@
 //  Created by 홍승현 on 1/31/24.
 //
 
+import Entity
 import Foundation
 
 public struct ProductResponse: Decodable {
   public let imageURL: URL
   public let price: Int
   public let name: String
-  public let promotion: String
-  public let convenienceStore: String
+  public let promotion: Promotion
+  public let convenienceStore: ConvenienceStore
+
+  public enum CodingKeys: String, CodingKey {
+    case imageURL = "image_url"
+    case price
+    case name
+    case promotion
+    case convenienceStore
+  }
 }

--- a/APIService/Sources/HomeAPI/Responses/ProductResponse.swift
+++ b/APIService/Sources/HomeAPI/Responses/ProductResponse.swift
@@ -1,0 +1,16 @@
+//
+//  ProductResponse.swift
+//
+//
+//  Created by 홍승현 on 1/31/24.
+//
+
+import Foundation
+
+public struct ProductResponse: Decodable {
+  public let imageURL: URL
+  public let price: Int
+  public let name: String
+  public let promotion: String
+  public let convenienceStore: String
+}

--- a/APIService/Sources/HomeAPI/Responses/ProductResponse.swift
+++ b/APIService/Sources/HomeAPI/Responses/ProductResponse.swift
@@ -9,6 +9,7 @@ import Entity
 import Foundation
 
 public struct ProductResponse: Decodable {
+  public let id: Int
   public let imageURL: URL
   public let price: Int
   public let name: String
@@ -16,6 +17,7 @@ public struct ProductResponse: Decodable {
   public let convenienceStore: ConvenienceStore
 
   public enum CodingKeys: String, CodingKey {
+    case id
     case imageURL = "image_url"
     case price
     case name

--- a/APIService/Sources/HomeAPISupport/HomeProductResponse.json
+++ b/APIService/Sources/HomeAPISupport/HomeProductResponse.json
@@ -1,85 +1,82 @@
-{
-  "count": 10,
-  "products": [
-    {
-      "date": "2024:01",
-      "img": "https://image.woodongs.com/imgsvr/item/GD_8809288634967_001.jpg",
-      "price": 2500,
-      "name": "BR)레인보우샤베트과즙워터500ML",
-      "tag": "1+1",
-      "store": "GS25"
-    },
-    {
-      "date": "2024:01",
-      "img": "https://image.woodongs.com/imgsvr/item/GD_8809288635315_003.jpg",
-      "price": 2500,
-      "name": "BR)망고탱고과즙워터500ML",
-      "tag": "1+1",
-      "store": "GS25"
-    },
-    {
-      "date": "2024:01",
-      "img": "https://image.woodongs.com/imgsvr/item/GD_8809288634974_001.jpg",
-      "price": 2500,
-      "name": "BR)피치요거트과즙워터500ML",
-      "tag": "1+1",
-      "store": "GS25"
-    },
-    {
-      "date": "2024:01",
-      "img": "https://image.woodongs.com/imgsvr/item/GD_8806002010861_865.jpg",
-      "price": 5000,
-      "name": "광동)헛개파워100ML",
-      "tag": "1+1",
-      "store": "GS25"
-    },
-    {
-      "date": "2024:01",
-      "img": "https://image.woodongs.com/imgsvr/item/GD_8806011416005_001.JPG",
-      "price": 5000,
-      "name": "동아)모닝케어D100ML",
-      "tag": "1+1",
-      "store": "GS25"
-    },
-    {
-      "date": "2024:01",
-      "img": "https://image.woodongs.com/imgsvr/item/GD_8806011415992_001.JPG",
-      "price": 5000,
-      "name": "동아)모닝케어H100ML",
-      "tag": "1+1",
-      "store": "GS25"
-    },
-    {
-      "date": "2024:01",
-      "img": "https://image.woodongs.com/imgsvr/item/GD_8809556566891_001.jpg",
-      "price": 5000,
-      "name": "서영)모닝이즈백100ML",
-      "tag": "1+1",
-      "store": "GS25"
-    },
-    {
-      "date": "2024:01",
-      "img": "https://image.woodongs.com/imgsvr/item/GD_8809125061857_002.jpg",
-      "price": 5000,
-      "name": "종근당)헛개땡큐골드100ML",
-      "tag": "1+1",
-      "store": "GS25"
-    },
-    {
-      "date": "2024:01",
-      "img": "https://image.woodongs.com/imgsvr/item/GD_8809329050015_018.jpg",
-      "price": 5000,
-      "name": "천지개벽)숙취해소음료100ML",
-      "tag": "1+1",
-      "store": "GS25"
-    },
-    {
-      "date": "2024:01",
-      "img": "https://image.woodongs.com/imgsvr/item/GD_8801013777260_001.jpg",
-      "price": 5000,
-      "name": "큐원)상쾌환부스터100ML",
-      "tag": "1+1",
-      "store": "GS25"
-    }
-  ]
-}
+[
+  {
+    "date": "2024:01",
+    "image_url": "https://image.woodongs.com/imgsvr/item/GD_8809288634967_001.jpg",
+    "price": 2500,
+    "name": "BR)레인보우샤베트과즙워터500ML",
+    "promotion": "1+1",
+    "convenienceStore": "GS25"
+  },
+  {
+    "date": "2024:01",
+    "image_url": "https://image.woodongs.com/imgsvr/item/GD_8809288635315_003.jpg",
+    "price": 2500,
+    "name": "BR)망고탱고과즙워터500ML",
+    "promotion": "1+1",
+    "convenienceStore": "GS25"
+  },
+  {
+    "date": "2024:01",
+    "image_url": "https://image.woodongs.com/imgsvr/item/GD_8809288634974_001.jpg",
+    "price": 2500,
+    "name": "BR)피치요거트과즙워터500ML",
+    "promotion": "1+1",
+    "convenienceStore": "GS25"
+  },
+  {
+    "date": "2024:01",
+    "image_url": "https://image.woodongs.com/imgsvr/item/GD_8806002010861_865.jpg",
+    "price": 5000,
+    "name": "광동)헛개파워100ML",
+    "promotion": "1+1",
+    "convenienceStore": "GS25"
+  },
+  {
+    "date": "2024:01",
+    "image_url": "https://image.woodongs.com/imgsvr/item/GD_8806011416005_001.JPG",
+    "price": 5000,
+    "name": "동아)모닝케어D100ML",
+    "promotion": "1+1",
+    "convenienceStore": "GS25"
+  },
+  {
+    "date": "2024:01",
+    "image_url": "https://image.woodongs.com/imgsvr/item/GD_8806011415992_001.JPG",
+    "price": 5000,
+    "name": "동아)모닝케어H100ML",
+    "promotion": "1+1",
+    "convenienceStore": "GS25"
+  },
+  {
+    "date": "2024:01",
+    "image_url": "https://image.woodongs.com/imgsvr/item/GD_8809556566891_001.jpg",
+    "price": 5000,
+    "name": "서영)모닝이즈백100ML",
+    "promotion": "1+1",
+    "convenienceStore": "GS25"
+  },
+  {
+    "date": "2024:01",
+    "image_url": "https://image.woodongs.com/imgsvr/item/GD_8809125061857_002.jpg",
+    "price": 5000,
+    "name": "종근당)헛개땡큐골드100ML",
+    "promotion": "1+1",
+    "convenienceStore": "GS25"
+  },
+  {
+    "date": "2024:01",
+    "image_url": "https://image.woodongs.com/imgsvr/item/GD_8809329050015_018.jpg",
+    "price": 5000,
+    "name": "천지개벽)숙취해소음료100ML",
+    "promotion": "1+1",
+    "convenienceStore": "GS25"
+  },
+  {
+    "date": "2024:01",
+    "image_url": "https://image.woodongs.com/imgsvr/item/GD_8801013777260_001.jpg",
+    "price": 5000,
+    "name": "큐원)상쾌환부스터100ML",
+    "promotion": "1+1",
+    "convenienceStore": "GS25"
+  }
+]

--- a/APIService/Sources/HomeAPISupport/HomeProductResponse.json
+++ b/APIService/Sources/HomeAPISupport/HomeProductResponse.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": 1,
     "date": "2024:01",
     "image_url": "https://image.woodongs.com/imgsvr/item/GD_8809288634967_001.jpg",
     "price": 2500,
@@ -8,6 +9,7 @@
     "convenienceStore": "GS25"
   },
   {
+    "id": 2,
     "date": "2024:01",
     "image_url": "https://image.woodongs.com/imgsvr/item/GD_8809288635315_003.jpg",
     "price": 2500,
@@ -16,6 +18,7 @@
     "convenienceStore": "GS25"
   },
   {
+    "id": 3,
     "date": "2024:01",
     "image_url": "https://image.woodongs.com/imgsvr/item/GD_8809288634974_001.jpg",
     "price": 2500,
@@ -24,6 +27,7 @@
     "convenienceStore": "GS25"
   },
   {
+    "id": 4,
     "date": "2024:01",
     "image_url": "https://image.woodongs.com/imgsvr/item/GD_8806002010861_865.jpg",
     "price": 5000,
@@ -32,6 +36,7 @@
     "convenienceStore": "GS25"
   },
   {
+    "id": 5,
     "date": "2024:01",
     "image_url": "https://image.woodongs.com/imgsvr/item/GD_8806011416005_001.JPG",
     "price": 5000,
@@ -40,6 +45,7 @@
     "convenienceStore": "GS25"
   },
   {
+    "id": 6,
     "date": "2024:01",
     "image_url": "https://image.woodongs.com/imgsvr/item/GD_8806011415992_001.JPG",
     "price": 5000,
@@ -48,6 +54,7 @@
     "convenienceStore": "GS25"
   },
   {
+    "id": 7,
     "date": "2024:01",
     "image_url": "https://image.woodongs.com/imgsvr/item/GD_8809556566891_001.jpg",
     "price": 5000,
@@ -56,6 +63,7 @@
     "convenienceStore": "GS25"
   },
   {
+    "id": 8,
     "date": "2024:01",
     "image_url": "https://image.woodongs.com/imgsvr/item/GD_8809125061857_002.jpg",
     "price": 5000,
@@ -64,6 +72,7 @@
     "convenienceStore": "GS25"
   },
   {
+    "id": 9,
     "date": "2024:01",
     "image_url": "https://image.woodongs.com/imgsvr/item/GD_8809329050015_018.jpg",
     "price": 5000,
@@ -72,6 +81,7 @@
     "convenienceStore": "GS25"
   },
   {
+    "id": 10,
     "date": "2024:01",
     "image_url": "https://image.woodongs.com/imgsvr/item/GD_8801013777260_001.jpg",
     "price": 5000,

--- a/Entity/.gitignore
+++ b/Entity/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Entity/Package.swift
+++ b/Entity/Package.swift
@@ -1,20 +1,16 @@
 // swift-tools-version: 5.9
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
   name: "Entity",
   products: [
-    // Products define the executables and libraries a package produces, making them visible to other packages.
     .library(
       name: "Entity",
       targets: ["Entity"]
     ),
   ],
   targets: [
-    // Targets are the basic building blocks of a package, defining a module or a test suite.
-    // Targets can depend on other targets in this package and products from dependencies.
     .target(
       name: "Entity"
     ),

--- a/Entity/Package.swift
+++ b/Entity/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+  name: "Entity",
+  products: [
+    // Products define the executables and libraries a package produces, making them visible to other packages.
+    .library(
+      name: "Entity",
+      targets: ["Entity"]
+    ),
+  ],
+  targets: [
+    // Targets are the basic building blocks of a package, defining a module or a test suite.
+    // Targets can depend on other targets in this package and products from dependencies.
+    .target(
+      name: "Entity"
+    ),
+  ]
+)

--- a/Entity/Sources/Entity/ConvenienceStore.swift
+++ b/Entity/Sources/Entity/ConvenienceStore.swift
@@ -1,0 +1,16 @@
+//
+//  ConvenienceStore.swift
+//
+//
+//  Created by 홍승현 on 1/31/24.
+//
+
+import Foundation
+
+public enum ConvenienceStore: String, Codable {
+  case cu = "CU"
+  case gs25 = "GS25"
+  case _7Eleven = "7-Eleven"
+  case emart24
+  case ministop = "MINISTOP"
+}

--- a/Entity/Sources/Entity/Order.swift
+++ b/Entity/Sources/Entity/Order.swift
@@ -1,0 +1,14 @@
+//
+//  Order.swift
+//
+//
+//  Created by 홍승현 on 1/31/24.
+//
+
+import Foundation
+
+public enum Order: String, Codable {
+  case normal
+  case ascending = "asc"
+  case descending = "desc"
+}

--- a/Entity/Sources/Entity/Product.swift
+++ b/Entity/Sources/Entity/Product.swift
@@ -19,8 +19,8 @@ public struct Product {
   public let name: String
 
   /// 행사 정보
-  public let promotion: String
+  public let promotion: Promotion
 
   /// 편의점
-  public let convenienceStore: String
+  public let convenienceStore: ConvenienceStore
 }

--- a/Entity/Sources/Entity/Product.swift
+++ b/Entity/Sources/Entity/Product.swift
@@ -1,0 +1,26 @@
+//
+//  Product.swift
+//
+//
+//  Created by 홍승현 on 1/31/24.
+//
+
+import Foundation
+
+/// 편의점 행사 제품에 대한 Entity Model입니다.
+public struct Product {
+  /// 이미지 URL
+  public let imageURL: URL
+
+  /// 제품 가격
+  public let price: Int
+
+  /// 제품명
+  public let name: String
+
+  /// 행사 정보
+  public let promotion: String
+
+  /// 편의점
+  public let convenienceStore: String
+}

--- a/Entity/Sources/Entity/Product.swift
+++ b/Entity/Sources/Entity/Product.swift
@@ -23,4 +23,18 @@ public struct Product {
 
   /// 편의점
   public let convenienceStore: ConvenienceStore
+
+  public init(
+    imageURL: URL,
+    price: Int,
+    name: String,
+    promotion: Promotion,
+    convenienceStore: ConvenienceStore
+  ) {
+    self.imageURL = imageURL
+    self.price = price
+    self.name = name
+    self.promotion = promotion
+    self.convenienceStore = convenienceStore
+  }
 }

--- a/Entity/Sources/Entity/Product.swift
+++ b/Entity/Sources/Entity/Product.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 /// 편의점 행사 제품에 대한 Entity Model입니다.
-public struct Product {
+public struct Product: Identifiable {
+  /// 제품 고유 Identifier
+  public let id: Int
+
   /// 이미지 URL
   public let imageURL: URL
 
@@ -25,12 +28,14 @@ public struct Product {
   public let convenienceStore: ConvenienceStore
 
   public init(
+    id: Int,
     imageURL: URL,
     price: Int,
     name: String,
     promotion: Promotion,
     convenienceStore: ConvenienceStore
   ) {
+    self.id = id
     self.imageURL = imageURL
     self.price = price
     self.name = name

--- a/Entity/Sources/Entity/Promotion.swift
+++ b/Entity/Sources/Entity/Promotion.swift
@@ -1,0 +1,15 @@
+//
+//  Promotion.swift
+//
+//
+//  Created by 홍승현 on 1/31/24.
+//
+
+import Foundation
+
+/// 행사 종류
+public enum Promotion: String, Codable {
+  case buyOneGetOneFree = "1+1"
+  case buyTwoGetOneFree = "2+1"
+  case allItems = "All"
+}

--- a/PyeonHaeng-iOS.xcodeproj/project.pbxproj
+++ b/PyeonHaeng-iOS.xcodeproj/project.pbxproj
@@ -28,11 +28,14 @@
 		BA28F1A42B61572A0052855E /* Pretendard-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA28F19A2B61572A0052855E /* Pretendard-ExtraBold.otf */; };
 		BA28F1A52B61572A0052855E /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA28F19B2B61572A0052855E /* Pretendard-Light.otf */; };
 		BA28F1A62B61572A0052855E /* Pretendard-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA28F19C2B61572A0052855E /* Pretendard-Black.otf */; };
+		BA4EA3602B6A37E10003DCE7 /* Entity in Frameworks */ = {isa = PBXBuildFile; productRef = BA4EA35F2B6A37E10003DCE7 /* Entity */; };
 		BAA4D9AD2B5A1795005999F8 /* PyeonHaengApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4D9AC2B5A1795005999F8 /* PyeonHaengApp.swift */; };
 		BAA4D9AF2B5A1795005999F8 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4D9AE2B5A1795005999F8 /* SplashView.swift */; };
 		BAA4D9B12B5A1796005999F8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BAA4D9B02B5A1796005999F8 /* Assets.xcassets */; };
 		BAA4D9B42B5A1796005999F8 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BAA4D9B32B5A1796005999F8 /* Preview Assets.xcassets */; };
 		BAB569612B639F3000D1E0F9 /* DesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = BAB569602B639F3000D1E0F9 /* DesignSystem */; };
+		BAB5CF252B6B7C5A008B24BF /* AppRootComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB5CF242B6B7C5A008B24BF /* AppRootComponent.swift */; };
+		BAB5CF272B6B7CF3008B24BF /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB5CF262B6B7CF3008B24BF /* HomeViewModel.swift */; };
 		BAE159D82B65FA6F002DCF94 /* HomeProductDetailSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE159D72B65FA6F002DCF94 /* HomeProductDetailSelectionView.swift */; };
 		BAE159DA2B65FC35002DCF94 /* HomeProductListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE159D92B65FC35002DCF94 /* HomeProductListView.swift */; };
 		BAE159DE2B663A9A002DCF94 /* HomeProductSorterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE159DD2B663A9A002DCF94 /* HomeProductSorterView.swift */; };
@@ -81,6 +84,8 @@
 		BAA4D9AE2B5A1795005999F8 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		BAA4D9B02B5A1796005999F8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BAA4D9B32B5A1796005999F8 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		BAB5CF242B6B7C5A008B24BF /* AppRootComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRootComponent.swift; sourceTree = "<group>"; };
+		BAB5CF262B6B7CF3008B24BF /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		BABFEA6F2B6399C30084C0EC /* Shared */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Shared; sourceTree = "<group>"; };
 		BAE159D72B65FA6F002DCF94 /* HomeProductDetailSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeProductDetailSelectionView.swift; sourceTree = "<group>"; };
 		BAE159D92B65FC35002DCF94 /* HomeProductListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeProductListView.swift; sourceTree = "<group>"; };
@@ -105,6 +110,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BA05640D2B6248EA003D6DC7 /* Network in Frameworks */,
+				BA4EA3602B6A37E10003DCE7 /* Entity in Frameworks */,
 				BA05640B2B6248EA003D6DC7 /* HomeAPISupport in Frameworks */,
 				BA0623D82B68E51400A0A3B2 /* Log in Frameworks */,
 				BA0564092B6248EA003D6DC7 /* HomeAPI in Frameworks */,
@@ -147,6 +153,7 @@
 			children = (
 				E5462C652B65677B00E9FDF2 /* PromotionTag.swift */,
 				BAA4D9AC2B5A1795005999F8 /* PyeonHaengApp.swift */,
+				BAB5CF242B6B7C5A008B24BF /* AppRootComponent.swift */,
 				E5462C6B2B65CF7800E9FDF2 /* Components */,
 				E5F2EC412B648EE500EE0838 /* Extensions */,
 				BA28F1722B61532C0052855E /* Scenes */,
@@ -195,6 +202,7 @@
 			isa = PBXGroup;
 			children = (
 				BA28F1872B6155910052855E /* HomeView.swift */,
+				BAB5CF262B6B7CF3008B24BF /* HomeViewModel.swift */,
 				BAE159D72B65FA6F002DCF94 /* HomeProductDetailSelectionView.swift */,
 				BAE159DD2B663A9A002DCF94 /* HomeProductSorterView.swift */,
 				BAE159D92B65FC35002DCF94 /* HomeProductListView.swift */,
@@ -344,6 +352,7 @@
 				BA05640C2B6248EA003D6DC7 /* Network */,
 				BAB569602B639F3000D1E0F9 /* DesignSystem */,
 				BA0623D72B68E51400A0A3B2 /* Log */,
+				BA4EA35F2B6A37E10003DCE7 /* Entity */,
 			);
 			productName = "PyeonHaeng-iOS";
 			productReference = BAA4D9A92B5A1795005999F8 /* PyeonHaeng-iOS.app */;
@@ -477,6 +486,7 @@
 				BAE159DA2B65FC35002DCF94 /* HomeProductListView.swift in Sources */,
 				E5F2EC402B637D4A00EE0838 /* ProductInfoHeader.swift in Sources */,
 				BA28F1852B6155810052855E /* OnboardingView.swift in Sources */,
+				BAB5CF272B6B7CF3008B24BF /* HomeViewModel.swift in Sources */,
 				BA28F1882B6155910052855E /* HomeView.swift in Sources */,
 				E5F2EC452B64926100EE0838 /* PromotionTagView.swift in Sources */,
 				BA28F18B2B6155BD0052855E /* ProductInfoView.swift in Sources */,
@@ -486,6 +496,7 @@
 				BA28F18E2B6156420052855E /* SettingsView.swift in Sources */,
 				BAE159DE2B663A9A002DCF94 /* HomeProductSorterView.swift in Sources */,
 				BAE159D82B65FA6F002DCF94 /* HomeProductDetailSelectionView.swift in Sources */,
+				BAB5CF252B6B7C5A008B24BF /* AppRootComponent.swift in Sources */,
 				BAA4D9AF2B5A1795005999F8 /* SplashView.swift in Sources */,
 				BAA4D9AD2B5A1795005999F8 /* PyeonHaengApp.swift in Sources */,
 			);
@@ -775,6 +786,10 @@
 		BA0623D72B68E51400A0A3B2 /* Log */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Log;
+		};
+		BA4EA35F2B6A37E10003DCE7 /* Entity */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Entity;
 		};
 		BAB569602B639F3000D1E0F9 /* DesignSystem */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/PyeonHaeng-iOS.xcodeproj/project.pbxproj
+++ b/PyeonHaeng-iOS.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		BA28F19B2B61572A0052855E /* Pretendard-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.otf"; sourceTree = "<group>"; };
 		BA28F19C2B61572A0052855E /* Pretendard-Black.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Black.otf"; sourceTree = "<group>"; };
 		BA28F1A72B6157E90052855E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BA4EA35A2B6A00F70003DCE7 /* Entity */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Entity; sourceTree = "<group>"; };
 		BAA4D9A92B5A1795005999F8 /* PyeonHaeng-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "PyeonHaeng-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BAA4D9AC2B5A1795005999F8 /* PyeonHaengApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyeonHaengApp.swift; sourceTree = "<group>"; };
 		BAA4D9AE2B5A1795005999F8 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
@@ -246,6 +247,7 @@
 		BAA4D9A02B5A1795005999F8 = {
 			isa = PBXGroup;
 			children = (
+				BA4EA35A2B6A00F70003DCE7 /* Entity */,
 				BABFEA6F2B6399C30084C0EC /* Shared */,
 				BA0564032B6219D4003D6DC7 /* APIService */,
 				BA0564022B62179A003D6DC7 /* Core */,

--- a/PyeonHaeng-iOS/Resources/Localizable.xcstrings
+++ b/PyeonHaeng-iOS/Resources/Localizable.xcstrings
@@ -2,51 +2,33 @@
   "sourceLanguage" : "en",
   "strings" : {
     "" : {
-
-    },
-    "총 %lld개의 상품이 있어요!" : {
-      "extractionState" : "manual",
       "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "There is a total of %lld product!"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "There are a total of %lld product!"
-                }
-              }
-            }
-          }
-        },
         "ja" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "合計%lld個の商品があります!"
-                }
-              }
-            }
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
           }
         },
         "ko" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "총 %lld개의 상품이 있어요!"
-                }
-              }
-            }
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        }
+      }
+    },
+    "%lld원" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld원"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld원"
           }
         }
       }
@@ -92,6 +74,53 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "제품 상세"
+          }
+        }
+      }
+    },
+    "총 %lld개의 상품이 있어요!" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "There is a total of %lld product!"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "There are a total of %lld product!"
+                }
+              }
+            }
+          }
+        },
+        "ja" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "合計%lld個の商品があります!"
+                }
+              }
+            }
+          }
+        },
+        "ko" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "총 %lld개의 상품이 있어요!"
+                }
+              }
+            }
           }
         }
       }

--- a/PyeonHaeng-iOS/Resources/Localizable.xcstrings
+++ b/PyeonHaeng-iOS/Resources/Localizable.xcstrings
@@ -2,33 +2,51 @@
   "sourceLanguage" : "en",
   "strings" : {
     "" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ""
-          }
-        }
-      }
+
     },
-    "%lld원" : {
+    "총 %lld개의 상품이 있어요!" : {
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "There is a total of %lld product!"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "There are a total of %lld product!"
+                }
+              }
+            }
+          }
+        },
         "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld원"
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "合計%lld個の商品があります!"
+                }
+              }
+            }
           }
         },
         "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld원"
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "총 %lld개의 상품이 있어요!"
+                }
+              }
+            }
           }
         }
       }
@@ -74,53 +92,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "제품 상세"
-          }
-        }
-      }
-    },
-    "총 %lld개의 상품이 있어요!" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "There is a total of %lld product!"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "There are a total of %lld product!"
-                }
-              }
-            }
-          }
-        },
-        "ja" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "合計%lld個の商品があります!"
-                }
-              }
-            }
-          }
-        },
-        "ko" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "총 %lld개의 상품이 있어요!"
-                }
-              }
-            }
           }
         }
       }

--- a/PyeonHaeng-iOS/Sources/AppRootComponent.swift
+++ b/PyeonHaeng-iOS/Sources/AppRootComponent.swift
@@ -1,0 +1,34 @@
+//
+//  AppRootComponent.swift
+//  PyeonHaeng-iOS
+//
+//  Created by 홍승현 on 2/1/24.
+//
+
+import Foundation
+import HomeAPI
+import HomeAPISupport
+import Network
+
+// MARK: - HomeDependency
+
+protocol HomeDependency {
+  var homeService: HomeServiceRepresentable { get }
+}
+
+// MARK: - AppRootComponent
+
+struct AppRootComponent: HomeDependency {
+  let homeService: HomeServiceRepresentable
+
+  init() {
+    let homeNetworking: Networking = {
+      let configuration = URLSessionConfiguration.ephemeral
+      configuration.protocolClasses = [HomeURLProtocol.self]
+      let provider = NetworkProvider(session: URLSession(configuration: configuration))
+      return provider
+    }()
+
+    homeService = HomeService(network: homeNetworking)
+  }
+}

--- a/PyeonHaeng-iOS/Sources/PyeonHaengApp.swift
+++ b/PyeonHaeng-iOS/Sources/PyeonHaengApp.swift
@@ -10,13 +10,15 @@ import SwiftUI
 
 @main
 struct PyeonHaengApp: App {
+  private let appComponent = AppRootComponent()
+
   init() {
     FontRegistrar.registerFonts() // 앱을 실행하기 전에 폰트를 로드합니다.
   }
 
   var body: some Scene {
     WindowGroup {
-      SplashView()
+      SplashView(dependency: appComponent)
     }
   }
 }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductListView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductListView.swift
@@ -108,14 +108,14 @@ private struct PriceView: View {
   var body: some View {
     HStack(spacing: 10) {
       Spacer()
-      Text(verbatim: "\(product.price.toStringWithComma())원")
+      Text("\(product.price)원")
         .font(.x2)
         .strikethrough()
         .foregroundColor(Color.gray200)
       HStack(spacing: 4) {
         Text("개당")
           .font(.c3)
-        Text(verbatim: "\(Int(product.price / 2).toStringWithComma())원")
+        Text("\(Int(product.price / 2))원")
           .font(.h4)
       }
       .foregroundStyle(Color.gray900)

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductListView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductListView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct HomeProductListView: View {
   private let items = Array(repeating: "펩시 제로 라임 250ml", count: 10)
+  @EnvironmentObject var viewModel: HomeViewModel
 
   var body: some View {
     List(items, id: \.self) { item in

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductListView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductListView.swift
@@ -108,14 +108,14 @@ private struct PriceView: View {
   var body: some View {
     HStack(spacing: 10) {
       Spacer()
-      Text(verbatim: "\(product.price.toStringWithComma())원")
+      Text(verbatim: "\(product.price.formatted())원")
         .font(.x2)
         .strikethrough()
         .foregroundColor(Color.gray200)
       HStack(spacing: 4) {
         Text("개당")
           .font(.c3)
-        Text(verbatim: "\(Int(product.price / 2).toStringWithComma())원")
+        Text(verbatim: "\(Int(product.price / 2).formatted())원")
           .font(.h4)
       }
       .foregroundStyle(Color.gray900)

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductListView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductListView.swift
@@ -108,14 +108,14 @@ private struct PriceView: View {
   var body: some View {
     HStack(spacing: 10) {
       Spacer()
-      Text("\(product.price)원")
+      Text(verbatim: "\(product.price.toStringWithComma())원")
         .font(.x2)
         .strikethrough()
         .foregroundColor(Color.gray200)
       HStack(spacing: 4) {
         Text("개당")
           .font(.c3)
-        Text("\(Int(product.price / 2))원")
+        Text(verbatim: "\(Int(product.price / 2).toStringWithComma())원")
           .font(.h4)
       }
       .foregroundStyle(Color.gray900)

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeView.swift
@@ -56,7 +56,3 @@ private extension HomeView {
     static let horizontal: CGFloat = 20
   }
 }
-
-#Preview {
-  HomeView()
-}

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeViewModel.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeViewModel.swift
@@ -1,0 +1,26 @@
+//
+//  HomeViewModel.swift
+//  PyeonHaeng-iOS
+//
+//  Created by 홍승현 on 2/1/24.
+//
+
+import Entity
+import Foundation
+import HomeAPI
+
+// MARK: - HomeViewModel
+
+@MainActor
+final class HomeViewModel: ObservableObject {
+  @Published var products: [Product] = []
+  private let service: HomeServiceRepresentable
+
+  init(service: HomeServiceRepresentable) {
+    self.service = service
+  }
+
+  func fetchProducts() async throws {
+    try await products.append(contentsOf: service.fetchProductList())
+  }
+}

--- a/PyeonHaeng-iOS/Sources/Scenes/SplashScene/SplashView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/SplashScene/SplashView.swift
@@ -16,20 +16,18 @@ struct SplashView: View {
   }
 
   var body: some View {
-    Group {
-      if showingSplash {
-        Text(verbatim: "SplashView")
-          .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-              withAnimation {
-                showingSplash = false
-              }
+    if showingSplash {
+      Text(verbatim: "SplashView")
+        .onAppear {
+          DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            withAnimation {
+              showingSplash = false
             }
           }
-      } else {
-        HomeView()
-          .environmentObject(HomeViewModel(service: dependency.homeService))
-      }
+        }
+    } else {
+      HomeView()
+        .environmentObject(HomeViewModel(service: dependency.homeService))
     }
   }
 }

--- a/PyeonHaeng-iOS/Sources/Scenes/SplashScene/SplashView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/SplashScene/SplashView.swift
@@ -8,6 +8,13 @@
 import SwiftUI
 
 struct SplashView: View {
+  @State private var showingSplash: Bool = true
+  private let dependency: HomeDependency
+
+  init(dependency: HomeDependency) {
+    self.dependency = dependency
+  }
+
   var body: some View {
     Text("")
   }

--- a/PyeonHaeng-iOS/Sources/Scenes/SplashScene/SplashView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/SplashScene/SplashView.swift
@@ -16,10 +16,24 @@ struct SplashView: View {
   }
 
   var body: some View {
-    Text("")
+    Group {
+      if showingSplash {
+        Text(verbatim: "SplashView")
+          .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+              withAnimation {
+                showingSplash = false
+              }
+            }
+          }
+      } else {
+        HomeView()
+          .environmentObject(HomeViewModel(service: dependency.homeService))
+      }
+    }
   }
 }
 
 #Preview {
-  SplashView()
+  SplashView(dependency: AppRootComponent())
 }


### PR DESCRIPTION
## Screenshots 📸

|영상|
|:-:|
|![RPReplay_Final1706783920](https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/e8070f17-ca18-4c2d-a80c-9ee228c6a571)|

|Dependency|
|:-:|
|![image](https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/97801f78-5d73-4490-a087-05ae1dea31c4)|

<br/><br/>

## 고민, 과정, 근거 💬

Entity를 모듈로 나누었습니다. APIService세부 모듈에 Entity가 존재하게 된다면, 다른 모듈에서 Entity를 참조할 수 없기 때문입니다(은근 공유하는 Entity 모델이 많아보이더라고요).

HomeViewModel을 이용하여 제품 리스트를 보여주어야 합니다.
그래서 HomeViewModel이 Network처리를 담당하는 Service를 갖도록 구현했고, 홈 화면에서 동작할 HomeService를 추가했습니다.
HomeService는 URLSession을 주입받기에, URLSession을 넣어줘야 합니다. 하지만 현재 API가 구현되어있지 않아 `URLProtocol`을 이용하여 Mock data를 가져오도록 처리해두었습니다. **나중에 API가 개발되면, URLSession.configuration만 수정하면 됩니다.**

HomeService는 루트에서 주입받도록 Dependency를 설정해주었습니다.

<br/><br/>

## References 📋

1. [WWDC - Testing Tips & Tricks](https://developer.apple.com/wwdc18/417?time=1200)

<br/><br/>

---

- Closed: #26
