### PR TITLE
[Home] 정렬 버튼 누를 때마다 모드 변경 및 접근성 추가, HomeViewModel 추상화

### DIFF
--- a/PyeonHaeng-iOS/Resources/Localizable.xcstrings
+++ b/PyeonHaeng-iOS/Resources/Localizable.xcstrings
@@ -106,6 +106,29 @@
         }
       }
     },
+    "기본 정렬" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General Sorting"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "般的な並び替え"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기본 정렬"
+          }
+        }
+      }
+    },
     "기존 가격" : {
       "localizations" : {
         "en" : {
@@ -124,6 +147,29 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "기존 가격"
+          }
+        }
+      }
+    },
+    "내림차순 정렬" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descending Sorting"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "降順並び替え"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "내림차순 정렬"
           }
         }
       }
@@ -260,24 +306,25 @@
         }
       }
     },
-    "정렬" : {
+    "오름차순 정렬" : {
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sort"
+            "value" : "Ascending Sorting"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "並び替え"
+            "value" : "昇順並び替え"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "정렬"
+            "value" : "오름차순 정렬"
           }
         }
       }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductListView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductListView.swift
@@ -19,9 +19,6 @@ struct HomeProductListView<ViewModel>: View where ViewModel: HomeViewModelRepres
       ProductRow(product: item)
         .listRowInsets(.init())
     }
-    .onAppear {
-      viewModel.trigger(.fetchMore)
-    }
     .listStyle(.plain)
     .scrollIndicators(.hidden)
   }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductListView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductListView.swift
@@ -11,18 +11,16 @@ import SwiftUI
 
 // MARK: - HomeProductListView
 
-struct HomeProductListView: View {
-  @EnvironmentObject var viewModel: HomeViewModel
+struct HomeProductListView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
+  @EnvironmentObject var viewModel: ViewModel
 
   var body: some View {
-    List(viewModel.products) { item in
+    List(viewModel.state.products) { item in
       ProductRow(product: item)
         .listRowInsets(.init())
     }
     .onAppear {
-      Task {
-        try await viewModel.fetchProducts()
-      }
+      viewModel.trigger(.fetchMore)
     }
     .listStyle(.plain)
     .scrollIndicators(.hidden)

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductSorterView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductSorterView.swift
@@ -25,9 +25,6 @@ struct HomeProductSorterView<ViewModel>: View where ViewModel: HomeViewModelRepr
       .accessibilityHint("더블 탭하여 정렬 기준을 바꿔보세요")
     }
     .padding(.all, 8)
-    .onAppear {
-      viewModel.trigger(.fetchCount)
-    }
   }
 
   var productCountString: AttributedString {

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductSorterView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductSorterView.swift
@@ -26,7 +26,7 @@ struct HomeProductSorterView<ViewModel>: View where ViewModel: HomeViewModelRepr
           .renderingMode(.template)
           .foregroundStyle(color(for: viewModel.state.order))
       }
-      .accessibilityLabel("정렬")
+      .accessibilityLabel(accessibilityLabel(for: viewModel.state.order))
       .accessibilityHint("더블 탭하여 정렬 기준을 바꿔보세요")
     }
     .padding(.all, 8)
@@ -62,6 +62,17 @@ private extension HomeProductSorterView {
     case .ascending,
          .descending:
       .green500
+    }
+  }
+
+  private func accessibilityLabel(for order: Order) -> LocalizedStringKey {
+    switch order {
+    case .normal:
+      "기본 정렬"
+    case .ascending:
+      "오름차순 정렬"
+    case .descending:
+      "내림차순 정렬"
     }
   }
 }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductSorterView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductSorterView.swift
@@ -8,9 +8,8 @@
 import DesignSystem
 import SwiftUI
 
-struct HomeProductSorterView: View {
-  @EnvironmentObject private var viewModel: HomeViewModel
-  @State private var count: Int = 0
+struct HomeProductSorterView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
+  @EnvironmentObject private var viewModel: ViewModel
 
   var body: some View {
     HStack {
@@ -27,16 +26,14 @@ struct HomeProductSorterView: View {
     }
     .padding(.all, 8)
     .onAppear {
-      Task {
-        count = try await viewModel.fetchProductCounts()
-      }
+      viewModel.trigger(.fetchCount)
     }
   }
 
   var productCountString: AttributedString {
-    var string = AttributedString(localized: "총 \(count)개의 상품이 있어요!")
+    var string = AttributedString(localized: "총 \(viewModel.state.count)개의 상품이 있어요!")
 
-    if let range = string.range(of: "\(count)") {
+    if let range = string.range(of: "\(viewModel.state.count)") {
       string[range].foregroundColor = .green500
     }
 

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductSorterView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductSorterView.swift
@@ -6,7 +6,10 @@
 //
 
 import DesignSystem
+import Entity
 import SwiftUI
+
+// MARK: - HomeProductSorterView
 
 struct HomeProductSorterView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
   @EnvironmentObject private var viewModel: ViewModel
@@ -16,17 +19,21 @@ struct HomeProductSorterView<ViewModel>: View where ViewModel: HomeViewModelRepr
       Text(productCountString)
         .font(.title2)
       Spacer()
-      Button {} label: {
-        Image.arrowDownArrowUp
+      Button {
+        viewModel.trigger(.changeOrder)
+      } label: {
+        image(for: viewModel.state.order)
           .renderingMode(.template)
-          .foregroundStyle(.gray200)
+          .foregroundStyle(color(for: viewModel.state.order))
       }
       .accessibilityLabel("정렬")
       .accessibilityHint("더블 탭하여 정렬 기준을 바꿔보세요")
     }
     .padding(.all, 8)
   }
+}
 
+private extension HomeProductSorterView {
   var productCountString: AttributedString {
     var string = AttributedString(localized: "총 \(viewModel.state.count)개의 상품이 있어요!")
 
@@ -35,5 +42,26 @@ struct HomeProductSorterView<ViewModel>: View where ViewModel: HomeViewModelRepr
     }
 
     return string
+  }
+
+  private func image(for order: Order) -> Image {
+    switch order {
+    case .normal:
+      .arrowDownArrowUp
+    case .descending:
+      .arrowDownToLine
+    case .ascending:
+      .arrowUpToLine
+    }
+  }
+
+  private func color(for order: Order) -> Color {
+    switch order {
+    case .normal:
+      .gray200
+    case .ascending,
+         .descending:
+      .green500
+    }
   }
 }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeView.swift
@@ -10,14 +10,21 @@ import SwiftUI
 
 // MARK: - HomeView
 
-struct HomeView: View {
+struct HomeView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
+  @StateObject private var viewModel: ViewModel
+
+  init(viewModel: @autoclosure @escaping () -> ViewModel) {
+    _viewModel = .init(wrappedValue: viewModel())
+  }
+
   var body: some View {
     NavigationStack {
       VStack {
         HomeProductDetailSelectionView()
-        HomeProductSorterView()
-        HomeProductListView()
+        HomeProductSorterView<ViewModel>()
+        HomeProductListView<ViewModel>()
       }
+      .environmentObject(viewModel)
       .padding(.horizontal, Metrics.horizontal)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
@@ -50,10 +57,8 @@ struct HomeView: View {
   }
 }
 
-// MARK: HomeView.Metrics
+// MARK: - Metrics
 
-private extension HomeView {
-  enum Metrics {
-    static let horizontal: CGFloat = 20
-  }
+private enum Metrics {
+  static let horizontal: CGFloat = 20
 }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeView.swift
@@ -55,7 +55,7 @@ struct HomeView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
       }
     }
     .onAppear {
-      viewModel.trigger(.fetchMore)
+      viewModel.trigger(.fetchProducts)
       viewModel.trigger(.fetchCount)
     }
   }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeView.swift
@@ -54,6 +54,10 @@ struct HomeView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
         }
       }
     }
+    .onAppear {
+      viewModel.trigger(.fetchMore)
+      viewModel.trigger(.fetchCount)
+    }
   }
 }
 

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeViewModel.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeViewModel.swift
@@ -13,7 +13,7 @@ import HomeAPI
 // MARK: - HomeAction
 
 enum HomeAction {
-  case fetchMore
+  case fetchProducts
   case fetchCount
   case changeOrder
 }
@@ -62,7 +62,7 @@ final class HomeViewModel: HomeViewModelRepresentable {
 
   private func render(as action: HomeAction) {
     switch action {
-    case .fetchMore:
+    case .fetchProducts:
       Task {
         try await fetchProducts()
       }
@@ -74,6 +74,7 @@ final class HomeViewModel: HomeViewModelRepresentable {
       state.order = if state.order == .normal { .descending }
       else if state.order == .descending { .ascending }
       else { .normal }
+      trigger(.fetchProducts)
     }
   }
 
@@ -86,7 +87,7 @@ final class HomeViewModel: HomeViewModelRepresentable {
       pageSize: state.pageSize,
       offset: state.offset
     )
-    try await state.products.append(contentsOf: service.fetchProductList(request: request))
+    try await state.products = service.fetchProductList(request: request)
   }
 
   private func fetchProductCounts() async throws {

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeViewModel.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeViewModel.swift
@@ -15,6 +15,7 @@ import HomeAPI
 enum HomeAction {
   case fetchMore
   case fetchCount
+  case changeOrder
 }
 
 // MARK: - HomeState
@@ -69,6 +70,10 @@ final class HomeViewModel: HomeViewModelRepresentable {
       Task {
         try await fetchProductCounts()
       }
+    case .changeOrder:
+      state.order = if state.order == .normal { .descending }
+      else if state.order == .descending { .ascending }
+      else { .normal }
     }
   }
 

--- a/PyeonHaeng-iOS/Sources/Scenes/SplashScene/SplashView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/SplashScene/SplashView.swift
@@ -26,8 +26,7 @@ struct SplashView: View {
           }
         }
     } else {
-      HomeView()
-        .environmentObject(HomeViewModel(service: dependency.homeService))
+      HomeView(viewModel: HomeViewModel(service: dependency.homeService))
     }
   }
 }


### PR DESCRIPTION
## Screenshots 📸

|정렬 버튼 토글 화면|
|:-:|
|![RPReplay_Final1707026082](https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/b3dd9d01-44ec-40cd-9227-9be68276b9e7)|

<br/><br/>

## 고민, 과정, 근거 💬

### 아키텍처 흐름 고민

각 하위 뷰마다 ViewModel을 참조하면서 동시에 하위뷰만의 `@State` 변수를 갖는 것은 데이터를 관리하기 어렵다고 판단하였고, `ViewModel`이 `Single source of truth`가 되도록 구현했습니다.
하위뷰가 이벤트를 받으면 ViewModel에게 업데이트를 요청하고, 받아온 데이터를 다시 자신의 `@State` 변수에 업데이트해주는 방식을 사용했었지만,
지금은 ViewModel에게 이벤트 전달 -> ViewModel에서 State 수정 -> 변경된 State에 의해 View 재생성 -> ViewModel에게 이벤트 전달 -> ...
과 같이 단방향 흐름으로 구성했습니다.

### 추상화

`ViewModel`과 `View`간 **DIP원칙**을 지키고 싶었습니다. 테스트를 할 때 MockViewModel을 주입하여 View의 특정 반응을 검증할 때 수월해지기 때문입니다.
그래서 `View`가 Concrete Type을 바라보지 않고 추상화된 타입을 바라보도록 구성하려 했으나 ViewModel은 `ObservableObject`를 채택해야하고, `ObservableObject`에는 `associatedtype`이 존재합니다.
결국 컴파일 시점에서 viewModel의 실제 타입 정보가 무엇으로 들어오는지 알 수 없게 됩니다.
그래서 Generic을 두어 `ViewModelRepresentable`을 채택한 구현체를 타입으로 두어 해결했습니다.

```swift
@MainActor protocol TestViewModelRepresentable: ObservableObject { /* ... */ }

final class TestViewModel: TestViewModelRepresentable { /* ... */ }

struct TestView1: View {
  @StateObject var viewModel: TestViewModelRepresentable // ❌ 오류
  // ...
}

// ✅ 성공
struct TestView2<T: TestViewModelRepresentable>: View {
  @StateObject var viewModel: T
}
```

## References 📋

1. [Initialize @StateObject with a parameter in SwiftUI](https://stackoverflow.com/questions/62635914/initialize-stateobject-with-a-parameter-in-swiftui)

---

- Closed: #37
