### PR TITLE
이전 행사 정보 UI를 구성한다.

### DIFF
--- a/PyeonHaeng-iOS/Resources/Localizable.xcstrings
+++ b/PyeonHaeng-iOS/Resources/Localizable.xcstrings
@@ -260,7 +260,7 @@
         }
       }
     },
-    "이전 행사 내역" : {
+    "이전 행사 정보" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -271,13 +271,13 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "過去のイベント"
+            "value" : "過去のプロモーション"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Previous Promotions"
+            "value" : "이전 행사 정보"
           }
         }
       }

--- a/PyeonHaeng-iOS/Resources/Localizable.xcstrings
+++ b/PyeonHaeng-iOS/Resources/Localizable.xcstrings
@@ -260,6 +260,28 @@
         }
       }
     },
+    "이전 행사 내역" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous Promotions"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去のイベント"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous Promotions"
+          }
+        }
+      }
+    },
     "정렬" : {
       "localizations" : {
         "en" : {

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoHeader.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoHeader.swift
@@ -55,6 +55,7 @@ struct ProductInfoHeader: View {
       }
       .foregroundStyle(Color.gray900)
     }
+    .padding(.bottom, 16.0)
   }
 }
 

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoLineGraphView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoLineGraphView.swift
@@ -17,6 +17,7 @@ struct ProductInfoLineGraphView: View {
   @State var prices: [Int]
 
   @State private var offset: CGSize = .zero
+  @State private var isFirstRender: Bool = false
 
   // MARK: - View
 
@@ -78,6 +79,10 @@ struct ProductInfoLineGraphView: View {
         .offset(offset)
       }
       .onAppear {
+        isFirstRender = true
+      }
+      .onChange(of: isFirstRender) {
+        guard isFirstRender else { return }
         if let lastPoint = points.dropLast().last {
           offset = CGSize(width: lastPoint.x - (Metrics.panelWidth / 2), height: 0)
         } else {
@@ -126,5 +131,5 @@ private extension ProductInfoLineGraphView {
 }
 
 #Preview(traits: .sizeThatFitsLayout) {
-  ProductInfoLineGraphView(prices: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  ProductInfoLineGraphView(prices: [1, 2])
 }

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoView.swift
@@ -18,7 +18,7 @@ struct ProductInfoView: View {
           .navigationTitle("제품 상세")
           .navigationBarTitleDisplayMode(.inline)
 
-        Text("이전 행사 내역")
+        Text("이전 행사 정보")
           .font(.title1)
           .foregroundStyle(.gray900)
           .frame(maxWidth: .infinity, alignment: .leading)

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoView.swift
@@ -5,6 +5,7 @@
 //  Created by 홍승현 on 1/24/24.
 //
 
+import DesignSystem
 import SwiftUI
 
 // MARK: - ProductInfoView
@@ -12,10 +13,19 @@ import SwiftUI
 struct ProductInfoView: View {
   var body: some View {
     NavigationStack {
-      VStack(spacing: 8.0) {
+      VStack {
         ProductInfoHeader()
           .navigationTitle("제품 상세")
           .navigationBarTitleDisplayMode(.inline)
+
+        Text("이전 행사 내역")
+          .font(.title1)
+          .foregroundStyle(.gray900)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(.top, 8.0)
+        ProductInfoLineGraphView(prices: [1150, 1300, 1400, 1200])
+          .padding(.top, 4.0)
+
         Spacer()
       }
       .padding(.horizontal, 20.0)


### PR DESCRIPTION
## Screenshots 📸

|구현 내용|
|:-:|
|![image](https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/97531269/3ed8c354-cf71-4fc2-8eb0-638eb35be4a9)|

<br/><br/>

## 고민, 과정, 근거 💬

- ~~구현한 그래프 UI를 이전행사내역에 추가했습니다.~~
- ~~뷰를 최초로 불러올 때, 그래프 가격 정보 패널이 이상한 위치에 있는 버그를 수정했습니다.~~
- ~~그래프의 Localization은 구체적인 데이터가 들어오면 구현할 계획에 있습니다.~~

브랜치가 추적이 되지 않는 문제점으로 다시 PR을 보냅니다!

<br/><br/>

## References 📋


<br/><br/>

---

- Closed: #36 

