### PR TITLE
편의점 바텀시트 구현

### DIFF
--- a/Entity/Sources/Entity/ConvenienceStore.swift
+++ b/Entity/Sources/Entity/ConvenienceStore.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 
-public enum ConvenienceStore: String, Codable {
+public enum ConvenienceStore: String, Codable, CaseIterable {
   case cu = "CU"
   case gs25 = "GS25"
   case _7Eleven = "7-ElEVEN"

--- a/PyeonHaeng-iOS.xcodeproj/project.pbxproj
+++ b/PyeonHaeng-iOS.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		BA28F1A42B61572A0052855E /* Pretendard-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA28F19A2B61572A0052855E /* Pretendard-ExtraBold.otf */; };
 		BA28F1A52B61572A0052855E /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA28F19B2B61572A0052855E /* Pretendard-Light.otf */; };
 		BA28F1A62B61572A0052855E /* Pretendard-Black.otf in Resources */ = {isa = PBXBuildFile; fileRef = BA28F19C2B61572A0052855E /* Pretendard-Black.otf */; };
+		BA402F7E2B85E31800E86AAD /* ConvenienceSelectBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA402F7D2B85E31800E86AAD /* ConvenienceSelectBottomSheetView.swift */; };
 		BA4EA3602B6A37E10003DCE7 /* Entity in Frameworks */ = {isa = PBXBuildFile; productRef = BA4EA35F2B6A37E10003DCE7 /* Entity */; };
 		BAA4D9AD2B5A1795005999F8 /* PyeonHaengApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4D9AC2B5A1795005999F8 /* PyeonHaengApp.swift */; };
 		BAA4D9AF2B5A1795005999F8 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA4D9AE2B5A1795005999F8 /* SplashView.swift */; };
@@ -87,6 +88,7 @@
 		BA28F19B2B61572A0052855E /* Pretendard-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Light.otf"; sourceTree = "<group>"; };
 		BA28F19C2B61572A0052855E /* Pretendard-Black.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Black.otf"; sourceTree = "<group>"; };
 		BA28F1A72B6157E90052855E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BA402F7D2B85E31800E86AAD /* ConvenienceSelectBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvenienceSelectBottomSheetView.swift; sourceTree = "<group>"; };
 		BA4EA35A2B6A00F70003DCE7 /* Entity */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Entity; sourceTree = "<group>"; };
 		BAA4D9A92B5A1795005999F8 /* PyeonHaeng-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "PyeonHaeng-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BAA4D9AC2B5A1795005999F8 /* PyeonHaengApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyeonHaengApp.swift; sourceTree = "<group>"; };
@@ -218,6 +220,7 @@
 		BA28F1862B61558C0052855E /* HomeScene */ = {
 			isa = PBXGroup;
 			children = (
+				BA402F7C2B85E2DE00E86AAD /* BottomSheet */,
 				BA28F1872B6155910052855E /* HomeView.swift */,
 				BAB5CF262B6B7CF3008B24BF /* HomeViewModel.swift */,
 				BAE159D72B65FA6F002DCF94 /* HomeProductDetailSelectionView.swift */,
@@ -269,6 +272,14 @@
 				BA28F1972B61572A0052855E /* Pretendard-Thin.otf */,
 			);
 			path = Fonts;
+			sourceTree = "<group>";
+		};
+		BA402F7C2B85E2DE00E86AAD /* BottomSheet */ = {
+			isa = PBXGroup;
+			children = (
+				BA402F7D2B85E31800E86AAD /* ConvenienceSelectBottomSheetView.swift */,
+			);
+			path = BottomSheet;
 			sourceTree = "<group>";
 		};
 		BAA4D9A02B5A1795005999F8 = {
@@ -505,6 +516,7 @@
 			files = (
 				BAE159DA2B65FC35002DCF94 /* HomeProductListView.swift in Sources */,
 				E5F2EC402B637D4A00EE0838 /* ProductInfoHeader.swift in Sources */,
+				BA402F7E2B85E31800E86AAD /* ConvenienceSelectBottomSheetView.swift in Sources */,
 				BA28F1852B6155810052855E /* OnboardingView.swift in Sources */,
 				BAB5CF272B6B7CF3008B24BF /* HomeViewModel.swift in Sources */,
 				BA28F1882B6155910052855E /* HomeView.swift in Sources */,

--- a/PyeonHaeng-iOS/Resources/Localizable.xcstrings
+++ b/PyeonHaeng-iOS/Resources/Localizable.xcstrings
@@ -39,6 +39,86 @@
         }
       }
     },
+    "7-Eleven" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7-Eleven"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "세븐일레븐"
+          }
+        }
+      }
+    },
+    "CU" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CU"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "씨유"
+          }
+        }
+      }
+    },
+    "Emart 24" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emart 24"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이마트 24"
+          }
+        }
+      }
+    },
+    "GS25" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GS25"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지에스 25"
+          }
+        }
+      }
+    },
+    "Ministop" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ministop"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미니스톱"
+          }
+        }
+      }
+    },
     "개당" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -306,28 +386,6 @@
         }
       }
     },
-    "이전 행사 정보" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Previous Promotions"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "過去のプロモーション"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이전 행사 정보"
-          }
-        }
-      }
-    },
     "오름차순 정렬" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -347,6 +405,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "오름차순 정렬"
+          }
+        }
+      }
+    },
+    "이전 행사 정보" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous Promotions"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去のプロモーション"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이전 행사 정보"
           }
         }
       }
@@ -416,6 +496,28 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "편의점 브랜드 선택" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose Store Brand"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コンビニのブランドを選ぶ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "편의점 브랜드 선택"
           }
         }
       }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/BottomSheet/ConvenienceSelectBottomSheetView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/BottomSheet/ConvenienceSelectBottomSheetView.swift
@@ -10,11 +10,12 @@ import SwiftUI
 
 // MARK: - ConvenienceSelectBottomSheetView
 
-struct ConvenienceSelectBottomSheetView: View {
-  @Binding private var convenienceStore: ConvenienceStore
+struct ConvenienceSelectBottomSheetView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
+  @EnvironmentObject private var viewModel: ViewModel
+  @Binding private var isPresented: Bool
 
-  init(convenienceStore: Binding<ConvenienceStore>) {
-    _convenienceStore = convenienceStore
+  init(isPresented: Binding<Bool>) {
+    _isPresented = isPresented
   }
 
   var body: some View {
@@ -24,12 +25,13 @@ struct ConvenienceSelectBottomSheetView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, Metrics.horizontalPadding)
 
-      ForEach(ConvenienceStore.allCases, id: \.self) { convenience in
+      ForEach(ConvenienceStore.allCases, id: \.self) { store in
         Button {
-          convenienceStore = convenience
+          viewModel.trigger(.changeConvenienceStore(store))
+          isPresented = false
         } label: {
-          ConvenienceSelectItem(convenience: convenience)
-            .frame(maxWidth: .infinity, alignment: .leading)
+          ConvenienceSelectItem(convenience: store)
+            .frame(maxWidth: .infinity, minHeight: Metrics.itemHeight, alignment: .leading)
         }
       }
       .padding(.horizontal, Metrics.itemHorizontalPadding)
@@ -98,9 +100,5 @@ private enum Metrics {
   static let itemHorizontalPadding: CGFloat = 24
   static let itemHorizontalSpacing: CGFloat = 12
   static let itemSpacing: CGFloat = 4
-}
-
-#Preview {
-  @State var convenience: ConvenienceStore = ._7Eleven
-  return ConvenienceSelectBottomSheetView(convenienceStore: $convenience)
+  static let itemHeight: CGFloat = 44
 }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/BottomSheet/ConvenienceSelectBottomSheetView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/BottomSheet/ConvenienceSelectBottomSheetView.swift
@@ -12,11 +12,7 @@ import SwiftUI
 
 struct ConvenienceSelectBottomSheetView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
   @EnvironmentObject private var viewModel: ViewModel
-  @Binding private var isPresented: Bool
-
-  init(isPresented: Binding<Bool>) {
-    _isPresented = isPresented
-  }
+  @Environment(\.dismiss) private var dismiss
 
   var body: some View {
     VStack(spacing: Metrics.itemSpacing) {
@@ -28,7 +24,7 @@ struct ConvenienceSelectBottomSheetView<ViewModel>: View where ViewModel: HomeVi
       ForEach(ConvenienceStore.allCases, id: \.self) { store in
         Button {
           viewModel.trigger(.changeConvenienceStore(store))
-          isPresented = false
+          dismiss()
         } label: {
           ConvenienceSelectItem(convenience: store)
             .frame(maxWidth: .infinity, minHeight: Metrics.itemHeight, alignment: .leading)

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/BottomSheet/ConvenienceSelectBottomSheetView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/BottomSheet/ConvenienceSelectBottomSheetView.swift
@@ -1,0 +1,106 @@
+//
+//  ConvenienceSelectBottomSheetView.swift
+//  PyeonHaeng-iOS
+//
+//  Created by 홍승현 on 2/21/24.
+//
+
+import Entity
+import SwiftUI
+
+// MARK: - ConvenienceSelectBottomSheetView
+
+struct ConvenienceSelectBottomSheetView: View {
+  @Binding private var convenienceStore: ConvenienceStore
+
+  init(convenienceStore: Binding<ConvenienceStore>) {
+    _convenienceStore = convenienceStore
+  }
+
+  var body: some View {
+    VStack(spacing: Metrics.itemSpacing) {
+      Text("편의점 브랜드 선택")
+        .font(.h3)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, Metrics.horizontalPadding)
+
+      ForEach(ConvenienceStore.allCases, id: \.self) { convenience in
+        Button {
+          convenienceStore = convenience
+        } label: {
+          ConvenienceSelectItem(convenience: convenience)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+      }
+      .padding(.horizontal, Metrics.itemHorizontalPadding)
+    }
+    .padding(.top, Metrics.topPadding)
+    .padding(.bottom, Metrics.bottomPadding)
+  }
+}
+
+// MARK: - ConvenienceSelectItem
+
+private struct ConvenienceSelectItem: View {
+  private let convenience: ConvenienceStore
+
+  init(convenience: ConvenienceStore) {
+    self.convenience = convenience
+  }
+
+  var body: some View {
+    HStack(spacing: Metrics.itemHorizontalSpacing) {
+      convenienceImageView()
+      convenienceText()
+    }
+  }
+
+  private func convenienceImageView() -> Image {
+    switch convenience {
+    case .cu:
+      .cu
+    case .gs25:
+      .gs25
+    case ._7Eleven:
+      ._7Eleven
+    case .emart24:
+      .emart24
+    case .ministop:
+      .ministop
+    }
+  }
+
+  private func convenienceText() -> Text {
+    switch convenience {
+    case .cu:
+      Text("CU")
+    case .gs25:
+      Text("GS25")
+    case ._7Eleven:
+      Text("7-Eleven")
+    case .emart24:
+      Text("Emart 24")
+    case .ministop:
+      Text("Ministop")
+    }
+  }
+}
+
+// MARK: - Metrics
+
+private enum Metrics {
+  static let topPadding: CGFloat = 12
+  static let bottomPadding: CGFloat = 4
+  static let horizontalPadding: CGFloat = 20
+
+  // MARK: Item
+
+  static let itemHorizontalPadding: CGFloat = 24
+  static let itemHorizontalSpacing: CGFloat = 12
+  static let itemSpacing: CGFloat = 4
+}
+
+#Preview {
+  @State var convenience: ConvenienceStore = ._7Eleven
+  return ConvenienceSelectBottomSheetView(convenienceStore: $convenience)
+}

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductDetailSelectionView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductDetailSelectionView.swift
@@ -30,8 +30,8 @@ struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeView
         }
       }
       .accessibilityHint("더블 탭하여 편의점을 선택하세요")
-      .sheet(isPresented: convenienceStoreModalPresented) {
-        ConvenienceSelectBottomSheetView<ViewModel>(isPresented: $convenienceStoreModalPresented)
+      .sheet(isPresented: $convenienceStoreModalPresented) {
+        ConvenienceSelectBottomSheetView<ViewModel>()
           .presentationDetents([.height(Metrics.bottomSheetHeight)])
           .presentationCornerRadius(20)
           .presentationBackground(.regularMaterial)

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductDetailSelectionView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductDetailSelectionView.swift
@@ -36,7 +36,7 @@ struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeView
       .accessibilityHint("더블 탭하여 편의점을 선택하세요")
       .sheet(isPresented: $isPresented) {
         ConvenienceSelectBottomSheetView<ViewModel>(isPresented: $isPresented)
-          .presentationDetents([.height(334)])
+          .presentationDetents([.height(Metrics.bottomSheetHeight)])
           .presentationCornerRadius(20)
           .presentationBackground(.regularMaterial)
       }
@@ -88,4 +88,5 @@ private enum Metrics {
   static let promotionButtonCornerRadius: CGFloat = 16
 
   static let height: CGFloat = 56
+  static let bottomSheetHeight: CGFloat = 334
 }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductDetailSelectionView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductDetailSelectionView.swift
@@ -10,10 +10,19 @@ import SwiftUI
 
 // MARK: - HomeProductDetailSelectionView
 
-struct HomeProductDetailSelectionView: View {
+struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
+  @EnvironmentObject private var viewModel: ViewModel
+  @Binding private var isPresented: Bool
+
+  init(isPresented: Binding<Bool>) {
+    _isPresented = isPresented
+  }
+
   var body: some View {
     HStack {
-      Button {} label: {
+      Button {
+        isPresented = true
+      } label: {
         Group {
           Image.gs25
             .resizable()
@@ -25,6 +34,12 @@ struct HomeProductDetailSelectionView: View {
         }
       }
       .accessibilityHint("더블 탭하여 편의점을 선택하세요")
+      .sheet(isPresented: $isPresented) {
+        ConvenienceSelectBottomSheetView<ViewModel>(isPresented: $isPresented)
+          .presentationDetents([.height(334)])
+          .presentationCornerRadius(20)
+          .presentationBackground(.regularMaterial)
+      }
 
       Spacer()
 
@@ -57,22 +72,20 @@ struct HomeProductDetailSelectionView: View {
   }
 }
 
-// MARK: HomeProductDetailSelectionView.Metrics
+// MARK: - Metrics
 
-private extension HomeProductDetailSelectionView {
-  enum Metrics {
-    static let buttonSpacing: CGFloat = 2
-    static let textHeight: CGFloat = 24
-    static let horizontal: CGFloat = 20
-    static let iconWidth: CGFloat = 8
-    static let iconHeight: CGFloat = 4
+private enum Metrics {
+  static let buttonSpacing: CGFloat = 2
+  static let textHeight: CGFloat = 24
+  static let horizontal: CGFloat = 20
+  static let iconWidth: CGFloat = 8
+  static let iconHeight: CGFloat = 4
 
-    static let promotionButtonPaddingTop: CGFloat = 4
-    static let promotionButtonPaddingLeading: CGFloat = 16
-    static let promotionButtonPaddingBottom: CGFloat = 4
-    static let promotionButtonPaddingTrailing: CGFloat = 10
-    static let promotionButtonCornerRadius: CGFloat = 16
+  static let promotionButtonPaddingTop: CGFloat = 4
+  static let promotionButtonPaddingLeading: CGFloat = 16
+  static let promotionButtonPaddingBottom: CGFloat = 4
+  static let promotionButtonPaddingTrailing: CGFloat = 10
+  static let promotionButtonCornerRadius: CGFloat = 16
 
-    static let height: CGFloat = 56
-  }
+  static let height: CGFloat = 56
 }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductDetailSelectionView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeProductDetailSelectionView.swift
@@ -12,16 +12,12 @@ import SwiftUI
 
 struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
   @EnvironmentObject private var viewModel: ViewModel
-  @Binding private var isPresented: Bool
-
-  init(isPresented: Binding<Bool>) {
-    _isPresented = isPresented
-  }
+  @State private var convenienceStoreModalPresented: Bool = false
 
   var body: some View {
     HStack {
       Button {
-        isPresented = true
+        convenienceStoreModalPresented = true
       } label: {
         Group {
           Image.gs25
@@ -34,8 +30,8 @@ struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeView
         }
       }
       .accessibilityHint("더블 탭하여 편의점을 선택하세요")
-      .sheet(isPresented: $isPresented) {
-        ConvenienceSelectBottomSheetView<ViewModel>(isPresented: $isPresented)
+      .sheet(isPresented: convenienceStoreModalPresented) {
+        ConvenienceSelectBottomSheetView<ViewModel>(isPresented: $convenienceStoreModalPresented)
           .presentationDetents([.height(Metrics.bottomSheetHeight)])
           .presentationCornerRadius(20)
           .presentationBackground(.regularMaterial)

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeView.swift
@@ -12,7 +12,6 @@ import SwiftUI
 
 struct HomeView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
   @StateObject private var viewModel: ViewModel
-  @State private var isPresented: Bool = false
 
   init(viewModel: @autoclosure @escaping () -> ViewModel) {
     _viewModel = .init(wrappedValue: viewModel())
@@ -21,7 +20,7 @@ struct HomeView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
   var body: some View {
     NavigationStack {
       VStack {
-        HomeProductDetailSelectionView<ViewModel>(isPresented: $isPresented)
+        HomeProductDetailSelectionView<ViewModel>()
         HomeProductSorterView<ViewModel>()
         HomeProductListView<ViewModel>()
       }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct HomeView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
   @StateObject private var viewModel: ViewModel
+  @State private var isPresented: Bool = false
 
   init(viewModel: @autoclosure @escaping () -> ViewModel) {
     _viewModel = .init(wrappedValue: viewModel())
@@ -20,7 +21,7 @@ struct HomeView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
   var body: some View {
     NavigationStack {
       VStack {
-        HomeProductDetailSelectionView()
+        HomeProductDetailSelectionView<ViewModel>(isPresented: $isPresented)
         HomeProductSorterView<ViewModel>()
         HomeProductListView<ViewModel>()
       }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeViewModel.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/HomeViewModel.swift
@@ -16,6 +16,7 @@ enum HomeAction {
   case fetchProducts
   case fetchCount
   case changeOrder
+  case changeConvenienceStore(ConvenienceStore)
 }
 
 // MARK: - HomeState
@@ -74,6 +75,9 @@ final class HomeViewModel: HomeViewModelRepresentable {
       state.order = if state.order == .normal { .descending }
       else if state.order == .descending { .ascending }
       else { .normal }
+      trigger(.fetchProducts)
+    case let .changeConvenienceStore(store):
+      state.store = store
       trigger(.fetchProducts)
     }
   }


### PR DESCRIPTION
## Screenshots 📸

|UI|
|:-:|
|![RPReplay_Final1708673376](https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/57ec1d9d-d174-403e-b59e-62c49d979ad6)|

## 고민, 과정, 근거 💬

### modal로 띄우기 위해 `isPresented`를 어디에 두어야할까

![image](https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/cc066051-f313-403b-80f6-3c1ac77b7727)

`Source of truth`를 ViewModel의 state로 한정하려고 했으나, 뷰를 모달로 띄우기 위해선 state를 수정할 권한을 뷰에게 주어야했습니다.
저는 state 변경을 View에서 하지 않고 ViewModel에서만 수정할 수 있도록 제한하고 싶어 결국 새로운 `Source of truth`를 추가했습니다.
다른 좋은 방법이 있다면 언제든 피드백 부탁드리겠습니다.. 🙇

---

- Closed: #47
