### PR TITLE
OnboardingView의  Localization

### DIFF
--- a/PyeonHaeng-iOS/Resources/Localizable.xcstrings
+++ b/PyeonHaeng-iOS/Resources/Localizable.xcstrings
@@ -260,6 +260,29 @@
         }
       }
     },
+    "건너뛰기" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skip"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スキップ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건너뛰기"
+          }
+        }
+      }
+    },
     "검색" : {
       "localizations" : {
         "en" : {
@@ -346,6 +369,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "내림차순 정렬"
+          }
+        }
+      }
+    },
+    "다양한 편의점의 1+1, 2+1 행사 제품 정보로\n알뜰하고 합리적으로 소비할수 있어요." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save money and shop wisely with various convenience store promotions such as 1+1, 2+1 offers."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1+1、2+1などの様々なコンビニエンスストアのプロモーションでお得に買い物をしましょう。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다양한 편의점의 1+1, 2+1 행사 제품 정보로\n알뜰하고 합리적으로 소비할수 있어요."
+          }
+        }
+      }
+    },
+    "다음" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次へ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음"
           }
         }
       }
@@ -482,6 +551,29 @@
         }
       }
     },
+    "수많은 혜택을 한곳에서" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Find numerous benefits in one place"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "たくさんの特典を1か所で見つけてください"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "수많은 혜택을 한곳에서"
+          }
+        }
+      }
+    },
     "오름차순 정렬" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -614,6 +706,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "편의점 브랜드 선택"
+          }
+        }
+      }
+    },
+    "편행 시작하기" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start PyeonHaeng"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ピョンヘン・スタート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "편행 시작하기"
+          }
+        }
+      }
+    },
+    "하나사면 하나 더" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buy one, get one free"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1つ購入すると1つ無料"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하나 사면 하나 더"
           }
         }
       }


### PR DESCRIPTION
## Screenshots 📸
<img width="436" alt="스크린샷 2024-02-27 오후 4 39 27" src="https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/76529148/09cea9e2-d806-49b1-ad7c-d0622f6e4411">
<img width="551" alt="스크린샷 2024-02-27 오후 4 51 03" src="https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/76529148/5d85d7fd-f828-4312-9dba-7a0cc1139839">


## 과정


- 한 : 편행시작하기
- 영 : Start PyeonHaeng
- 일 : ピョンヘン・スタート

<br>

- 한 : 건너뛰기
- 영 : Skip
- 일 : スキップ

<br>

- 한 : 하나사면 하나 더
- 영 : Buy one, get one free
- 일 : 1つ購入すると1つ無料

<br>

- 한 : 다양한 편의점의 1+1, 2+1 행사 제품 정보로 알뜰하고 합리적으로 소비할수 있어요.
- 영 : Save money and shop wisely with various convenience store promotions such as 1+1, 2+1 offers.
- 일 : 1+1、2+1などの様々なコンビニエンスストアのプロモーションでお得に買い物をしましょう。

<br>

- 한 : 세븐일레븐, CU, 이마트 24, GS 25, 미니스톱의 수많은 행사정보를 ‘편행’한곳에서 만나보세요.
- 영 : Explore abundant promotional information from 7-Eleven, CU, Emart 24, GS 25, and Ministop in one place.
- 일 : 7-Eleven、CU、Emart 24、GS 25、Ministopの多くのプロモーション情報を1か所でご覧ください。

<br>

- 한 : 수많은 혜택을 한곳에서
- 영 : Find numerous benefits in one place
- 일 : たくさんの特典を1か所で見つけてください

+++

추가로  통일하고 싶은건 여기에 7-Eleven, 씨유, 지에스  이렇게 기존에 되어있는거에 통일이 필요할 거 같은데, 어떻게 생각하시나요??

저는 기존에 피그마에 있는 문구로 작업하긴 했습니다.

<br/><br/>

---
- Closed: #54
