### PR TITLE
편의점 선택 시 편의점 로고로 변경

### DIFF
--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductDetailSelectionView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductDetailSelectionView.swift
@@ -20,7 +20,7 @@ struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeView
         convenienceStoreModalPresented = true
       } label: {
         Group {
-          Image.gs25
+          convenienceImageView()
             .resizable()
             .scaledToFit()
           Image.chevronDown
@@ -65,6 +65,21 @@ struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeView
       }
     }
     .frame(height: Metrics.height)
+  }
+
+  private func convenienceImageView() -> Image {
+    switch viewModel.state.productConfiguration.store {
+    case .cu:
+      .cu
+    case .gs25:
+      .gs25
+    case ._7Eleven:
+      ._7Eleven
+    case .emart24:
+      .emart24
+    case .ministop:
+      .ministop
+    }
   }
 }
 


### PR DESCRIPTION
## Screenshots 📸

|편의점 로고 변경 화면|
|:-:|
|![Simulator Screen Recording - iPhone 15 Pro - 2024-03-01 at 14 22 51](https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/e802c2f4-c348-447f-97fc-060c1599688f)|

<br/><br/>

## 고민, 과정, 근거 💬

- 편의점 로고를 gs25로 고정해두었는데, 별도의 메서드를 만들어서 viewModel 값에 따라 편의점 로고를 변경할 수 있도록 수정했습니다.

---

- Closed: #67
