### PR TITLE
프로모션 선택 시 바텀시트 표시 / 툴바 아이콘 색상 수정 / 다크모드 연동

### DIFF
--- a/Entity/Sources/Entity/Promotion.swift
+++ b/Entity/Sources/Entity/Promotion.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// 행사 종류
-public enum Promotion: String, Codable {
+public enum Promotion: String, Codable, CaseIterable {
   case buyOneGetOneFree = "1+1"
   case buyTwoGetOneFree = "2+1"
   case allItems = "All"

--- a/PyeonHaeng-iOS.xcodeproj/project.pbxproj
+++ b/PyeonHaeng-iOS.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		BAB569612B639F3000D1E0F9 /* DesignSystem in Frameworks */ = {isa = PBXBuildFile; productRef = BAB569602B639F3000D1E0F9 /* DesignSystem */; };
 		BAB5CF252B6B7C5A008B24BF /* AppRootComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB5CF242B6B7C5A008B24BF /* AppRootComponent.swift */; };
 		BAB5CF272B6B7CF3008B24BF /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB5CF262B6B7CF3008B24BF /* HomeViewModel.swift */; };
+		BAB720342B9325F200C2CA1A /* PromotionSelectBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB720332B9325F200C2CA1A /* PromotionSelectBottomSheetView.swift */; };
 		BAE159D82B65FA6F002DCF94 /* HomeProductDetailSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE159D72B65FA6F002DCF94 /* HomeProductDetailSelectionView.swift */; };
 		BAE159DA2B65FC35002DCF94 /* HomeProductListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE159D92B65FC35002DCF94 /* HomeProductListView.swift */; };
 		BAE159DE2B663A9A002DCF94 /* HomeProductSorterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE159DD2B663A9A002DCF94 /* HomeProductSorterView.swift */; };
@@ -102,6 +103,7 @@
 		BAA4D9B32B5A1796005999F8 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		BAB5CF242B6B7C5A008B24BF /* AppRootComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRootComponent.swift; sourceTree = "<group>"; };
 		BAB5CF262B6B7CF3008B24BF /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		BAB720332B9325F200C2CA1A /* PromotionSelectBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionSelectBottomSheetView.swift; sourceTree = "<group>"; };
 		BABFEA6F2B6399C30084C0EC /* Shared */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Shared; sourceTree = "<group>"; };
 		BAE159D72B65FA6F002DCF94 /* HomeProductDetailSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeProductDetailSelectionView.swift; sourceTree = "<group>"; };
 		BAE159D92B65FC35002DCF94 /* HomeProductListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeProductListView.swift; sourceTree = "<group>"; };
@@ -279,6 +281,7 @@
 			isa = PBXGroup;
 			children = (
 				BA402F7D2B85E31800E86AAD /* ConvenienceSelectBottomSheetView.swift */,
+				BAB720332B9325F200C2CA1A /* PromotionSelectBottomSheetView.swift */,
 			);
 			path = BottomSheet;
 			sourceTree = "<group>";
@@ -549,6 +552,7 @@
 				BA28F18B2B6155BD0052855E /* ProductInfoView.swift in Sources */,
 				E5462C662B65677B00E9FDF2 /* PromotionTag.swift in Sources */,
 				E50584532B763C8C002FDACF /* ProductInfoViewModel.swift in Sources */,
+				BAB720342B9325F200C2CA1A /* PromotionSelectBottomSheetView.swift in Sources */,
 				BA28F1912B61566E0052855E /* ProductSearchView.swift in Sources */,
 				9CE4B4732B6F0BA3002DC446 /* OnboardingViewModel.swift in Sources */,
 				9CE4B4752B6F78E8002DC446 /* OnboardingPageControl.swift in Sources */,

--- a/PyeonHaeng-iOS/Resources/Localizable.xcstrings
+++ b/PyeonHaeng-iOS/Resources/Localizable.xcstrings
@@ -39,6 +39,38 @@
         }
       }
     },
+    "1+1" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1+1"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1+1"
+          }
+        }
+      }
+    },
+    "2+1" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2+1"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2+1"
+          }
+        }
+      }
+    },
     "7-Eleven" : {
       "localizations" : {
         "ja" : {
@@ -51,6 +83,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "세븐일레븐"
+          }
+        }
+      }
+    },
+    "All(View All)" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All（全て表示）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All(전체보기)"
           }
         }
       }
@@ -195,6 +243,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "알림"
+          }
+        }
+      }
+    },
+    "Select Promotion Items" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プロモション商品選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "행사 품목 선택"
           }
         }
       }

--- a/PyeonHaeng-iOS/Sources/PyeonHaengApp.swift
+++ b/PyeonHaeng-iOS/Sources/PyeonHaengApp.swift
@@ -29,7 +29,7 @@ struct PyeonHaengApp: App {
   private func setupNavigationBarAppearance() {
     // 네비게이션 바 스크롤 엣지 외관을 설정하기 위한 UINavigationBarAppearance 객체 생성
     let appearance = UINavigationBarAppearance()
-    appearance.backgroundColor = .white // 배경색을 하얀색으로 설정
+    appearance.backgroundColor = .systemBackground // 배경색을 하얀색으로 설정
     appearance.shadowColor = .clear // 그림자 제거
     appearance.titleTextAttributes = [
       .foregroundColor: UIColor(Color.gray900),

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/BottomSheet/ConvenienceSelectBottomSheetView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/BottomSheet/ConvenienceSelectBottomSheetView.swift
@@ -5,6 +5,7 @@
 //  Created by 홍승현 on 2/21/24.
 //
 
+import DesignSystem
 import Entity
 import SwiftUI
 
@@ -32,6 +33,7 @@ struct ConvenienceSelectBottomSheetView<ViewModel>: View where ViewModel: HomeVi
       }
       .padding(.horizontal, Metrics.itemHorizontalPadding)
     }
+    .foregroundStyle(.gray900)
     .padding(.top, Metrics.topPadding)
     .padding(.bottom, Metrics.bottomPadding)
   }
@@ -50,6 +52,7 @@ private struct ConvenienceSelectItem: View {
     HStack(spacing: Metrics.itemHorizontalSpacing) {
       convenienceImageView()
       convenienceText()
+        .font(.body2)
     }
   }
 

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/BottomSheet/PromotionSelectBottomSheetView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/BottomSheet/PromotionSelectBottomSheetView.swift
@@ -1,0 +1,82 @@
+//
+//  PromotionSelectBottomSheetView.swift
+//  PyeonHaeng-iOS
+//
+//  Created by 홍승현 on 3/2/24.
+//
+
+import Entity
+import SwiftUI
+
+// MARK: - PromotionSelectBottomSheetView
+
+struct PromotionSelectBottomSheetView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
+  // MARK: Properties
+
+  @EnvironmentObject private var viewModel: ViewModel
+  @Environment(\.dismiss) private var dismiss
+
+  // MARK: Body - View
+
+  var body: some View {
+    VStack(spacing: Metrics.itemSpacing) {
+      titleView
+      promotionButtons
+    }
+    .padding(.top, Metrics.topPadding)
+    .padding(.bottom, Metrics.bottomPadding)
+  }
+
+  // MARK: SubViews
+
+  private var titleView: some View {
+    Text("Select Promotion Items")
+      .font(.h3)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(.horizontal, Metrics.horizontalPadding)
+  }
+
+  private var promotionButtons: some View {
+    ForEach(Promotion.allCases, id: \.self) { promotion in
+      Button {
+        viewModel.changePromotion(to: promotion)
+        dismiss()
+      } label: {
+        Text(promotion.displayName)
+          .frame(maxWidth: .infinity, minHeight: Metrics.itemHeight, alignment: .leading)
+      }
+    }
+    .padding(.horizontal, Metrics.itemHorizontalPadding)
+  }
+}
+
+private extension HomeViewModelRepresentable {
+  func changePromotion(to promotion: Promotion) {
+    trigger(.changePromotion(promotion))
+  }
+}
+
+private extension Promotion {
+  var displayName: LocalizedStringKey {
+    switch self {
+    case .allItems: "All(View All)"
+    case .buyOneGetOneFree: "1+1"
+    case .buyTwoGetOneFree: "2+1"
+    }
+  }
+}
+
+// MARK: - Metrics
+
+private enum Metrics {
+  static let topPadding: CGFloat = 12
+  static let bottomPadding: CGFloat = 4
+  static let horizontalPadding: CGFloat = 20
+
+  // MARK: Item
+
+  static let itemHorizontalPadding: CGFloat = 24
+  static let itemHorizontalSpacing: CGFloat = 12
+  static let itemSpacing: CGFloat = 4
+  static let itemHeight: CGFloat = 44
+}

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/BottomSheet/PromotionSelectBottomSheetView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/BottomSheet/PromotionSelectBottomSheetView.swift
@@ -5,6 +5,7 @@
 //  Created by 홍승현 on 3/2/24.
 //
 
+import DesignSystem
 import Entity
 import SwiftUI
 
@@ -23,6 +24,7 @@ struct PromotionSelectBottomSheetView<ViewModel>: View where ViewModel: HomeView
       titleView
       promotionButtons
     }
+    .foregroundStyle(.gray900)
     .padding(.top, Metrics.topPadding)
     .padding(.bottom, Metrics.bottomPadding)
   }
@@ -43,6 +45,7 @@ struct PromotionSelectBottomSheetView<ViewModel>: View where ViewModel: HomeView
         dismiss()
       } label: {
         Text(promotion.displayName)
+          .font(.body2)
           .frame(maxWidth: .infinity, minHeight: Metrics.itemHeight, alignment: .leading)
       }
     }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductDetailSelectionView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductDetailSelectionView.swift
@@ -13,6 +13,7 @@ import SwiftUI
 struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
   @EnvironmentObject private var viewModel: ViewModel
   @State private var convenienceStoreModalPresented: Bool = false
+  @State private var promotionModalPresented: Bool = false
 
   var body: some View {
     HStack {
@@ -32,14 +33,16 @@ struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeView
       .accessibilityHint("더블 탭하여 편의점을 선택하세요")
       .sheet(isPresented: $convenienceStoreModalPresented) {
         ConvenienceSelectBottomSheetView<ViewModel>()
-          .presentationDetents([.height(Metrics.bottomSheetHeight)])
+          .presentationDetents([.height(Metrics.convenienceBottomSheetHeight)])
           .presentationCornerRadius(20)
           .presentationBackground(.regularMaterial)
       }
 
       Spacer()
 
-      Button {} label: {
+      Button {
+        promotionModalPresented = true
+      } label: {
         HStack(spacing: Metrics.buttonSpacing) {
           Text(verbatim: "All")
             .font(.title2)
@@ -62,6 +65,12 @@ struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeView
         RoundedRectangle(cornerRadius: Metrics.promotionButtonCornerRadius)
           .stroke()
           .foregroundStyle(.gray400)
+      }
+      .sheet(isPresented: $promotionModalPresented) {
+        PromotionSelectBottomSheetView<ViewModel>()
+          .presentationDetents([.height(Metrics.promotionBottomSheetHeight)])
+          .presentationCornerRadius(20)
+          .presentationBackground(.regularMaterial)
       }
     }
     .frame(height: Metrics.height)
@@ -99,5 +108,6 @@ private enum Metrics {
   static let promotionButtonCornerRadius: CGFloat = 16
 
   static let height: CGFloat = 56
-  static let bottomSheetHeight: CGFloat = 334
+  static let convenienceBottomSheetHeight: CGFloat = 334
+  static let promotionBottomSheetHeight: CGFloat = 238
 }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeView.swift
@@ -44,6 +44,8 @@ struct HomeView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
         ToolbarItem(placement: .topBarLeading) {
           HStack {
             Image.store
+              .renderingMode(.template)
+              .foregroundStyle(.gray900)
           }
         }
 
@@ -53,6 +55,8 @@ struct HomeView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
               .toolbarRole(.editor)
           } label: {
             Image.magnifyingglass
+              .renderingMode(.template)
+              .foregroundStyle(.gray900)
           }
           .accessibilityLabel("검색")
           .accessibilityHint("더블 탭하여 제품을 검색하세요")
@@ -61,6 +65,8 @@ struct HomeView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
               .toolbarRole(.editor)
           } label: {
             Image.gearshape
+              .renderingMode(.template)
+              .foregroundStyle(.gray900)
           }
           .accessibilityLabel("설정")
           .accessibilityHint("더블 탭하여 설정에 관한 기능을 확인하세요")

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeView.swift
@@ -29,7 +29,7 @@ struct HomeView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
           }
           .background(
             LinearGradient(
-              colors: [.white, .white.opacity(0.9)],
+              colors: [.init(.systemBackground), .init(.systemBackground).opacity(0.9)],
               startPoint: .top,
               endPoint: .bottom
             )

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/ViewModel/HomeViewModel.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/ViewModel/HomeViewModel.swift
@@ -18,6 +18,7 @@ enum HomeAction {
   case fetchCount
   case changeOrder
   case changeConvenienceStore(ConvenienceStore)
+  case changePromotion(Promotion)
 }
 
 // MARK: - HomeState
@@ -93,6 +94,10 @@ final class HomeViewModel: HomeViewModelRepresentable {
 
     case let .changeConvenienceStore(store):
       state.productConfiguration.change(convenienceStore: store)
+      trigger(.fetchProducts)
+
+    case let .changePromotion(promotion):
+      state.productConfiguration.change(promotion: promotion)
       trigger(.fetchProducts)
     }
   }


### PR DESCRIPTION
## Screenshots 📸

|동작 화면|
|:-:|
|![RPReplay_Final1709382830](https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/da790243-6cd4-4752-b01c-4c9571376252)|

<br/><br/>

## 고민, 과정, 근거 💬

### Fix ✍️

- 다크모드일 때 하얀색으로 보이는 현상을 수정했습니다. (그래디언트 색상을 white에서 systemBackground로 변경)
- 툴바 아이콘이 다크모드일 때 주간모드의 색상을 그대로 표시하고 있었고, 이를 수정했습니다.

### Feature ✨

- 바텀시트 뷰를 추가해서 버튼 클릭시 보여지도록 구현했습니다.

<br/><br/>

---

- Closed: #70
