### PR TITLE
제품 개수 API 연결 / home 화면 tint 설정

### DIFF
--- a/APIService/Sources/HomeAPI/Requests/ProductCountRequest.swift
+++ b/APIService/Sources/HomeAPI/Requests/ProductCountRequest.swift
@@ -8,10 +8,23 @@
 import Entity
 import Foundation
 
+// MARK: - ProductCountRequest
+
 public struct ProductCountRequest: Encodable {
   public let convenienceStore: ConvenienceStore
+  public let promotion: Promotion
 
-  public init(convenienceStore: ConvenienceStore) {
+  public init(convenienceStore: ConvenienceStore, promotion: Promotion) {
     self.convenienceStore = convenienceStore
+    self.promotion = promotion
+  }
+}
+
+// MARK: ProductCountRequest.CodingKeys
+
+extension ProductCountRequest {
+  enum CodingKeys: String, CodingKey {
+    case convenienceStore = "store"
+    case promotion
   }
 }

--- a/APIService/Sources/HomeAPISupport/HomeURLProtocol.swift
+++ b/APIService/Sources/HomeAPISupport/HomeURLProtocol.swift
@@ -15,7 +15,7 @@ public final class HomeURLProtocol: URLProtocol {
       .init(store: .gs25, promotion: .allItems, order: .normal, pageSize: 0, offset: 0)
     ).path: loadMockData(fileName: "HomeProductResponse"),
     HomeEndPoint.fetchCount(
-      .init(convenienceStore: .gs25)
+      .init(convenienceStore: .gs25, promotion: .allItems)
     ).path: loadMockData(fileName: "HomeProductCountResponse"),
   ]
 

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductSorterView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductSorterView.swift
@@ -37,7 +37,7 @@ private extension HomeProductSorterView {
   var productCountString: AttributedString {
     var string = AttributedString(localized: "총 \(viewModel.state.totalCount)개의 상품이 있어요!")
 
-    if let range = string.range(of: "\(viewModel.state.totalCount)") {
+    if let range = string.range(of: "\(viewModel.state.totalCount.formatted())") {
       string[range].foregroundColor = .green500
     }
 

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeView.swift
@@ -67,6 +67,7 @@ struct HomeView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
         }
       }
     }
+    .tint(.accent)
     .onAppear {
       viewModel.trigger(.fetchProducts)
       viewModel.trigger(.fetchCount)

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/ViewModel/HomeViewModel.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/ViewModel/HomeViewModel.swift
@@ -90,10 +90,12 @@ final class HomeViewModel: HomeViewModelRepresentable {
     case .changeOrder:
       state.productConfiguration.toggleOrder()
       trigger(.fetchProducts)
+      trigger(.fetchCount)
 
     case let .changeConvenienceStore(store):
       state.productConfiguration.change(convenienceStore: store)
       trigger(.fetchProducts)
+      trigger(.fetchCount)
     }
   }
 
@@ -126,8 +128,12 @@ final class HomeViewModel: HomeViewModelRepresentable {
   }
 
   private func fetchProductCounts() async throws {
-    // TODO: 편의점 선택 뷰를 구성할 때 수정해야합니다.
-    let total = try await service.fetchProductCount(request: .init(convenienceStore: state.productConfiguration.store))
+    let total = try await service.fetchProductCount(
+      request: .init(
+        convenienceStore: state.productConfiguration.store,
+        promotion: state.productConfiguration.promotion
+      )
+    )
     state.totalCount = total
   }
 }


### PR DESCRIPTION
## Screenshots 📸

|적용 화면|
|:-:|
|![image](https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/e08153ef-5f85-4de2-8877-2d26f8d0fa95)|

<br/><br/>

## 고민, 과정, 근거 💬

백엔드 API가 변경돼서 이를 반영했습니다.
Navigation이 push될 때 back button의 색이 blue로 변경되는 현상을 `tint(.accent)`로 수정했습니다.

---

- Closed: #74
