### PR TITLE
SearchAPI 서비스 및 테스트 네트워크 코드 추가 

### DIFF
--- a/APIService/Package.swift
+++ b/APIService/Package.swift
@@ -22,6 +22,14 @@ let package = Package(
       name: "ProductInfoAPISupport",
       targets: ["ProductInfoAPISupport"]
     ),
+    .library(
+      name: "SearchAPI",
+      targets: ["SearchAPI"]
+    ),
+    .library(
+      name: "SearchAPISupport",
+      targets: ["SearchAPISupport"]
+    ),
   ],
   dependencies: [
     .package(path: "../Core"),
@@ -53,6 +61,20 @@ let package = Package(
       name: "ProductInfoAPISupport",
       dependencies: [
         "ProductInfoAPI",
+      ],
+      resources: [.process("Mocks")]
+    ),
+    .target(
+      name: "SearchAPI",
+      dependencies: [
+        .product(name: "Network", package: "Core"),
+        .product(name: "Entity", package: "Entity"),
+      ]
+    ),
+    .target(
+      name: "SearchAPISupport",
+      dependencies: [
+        "SearchAPI",
       ],
       resources: [.process("Mocks")]
     ),

--- a/APIService/Sources/SearchAPI/Requests/SearchProductRequest.swift
+++ b/APIService/Sources/SearchAPI/Requests/SearchProductRequest.swift
@@ -1,0 +1,30 @@
+//
+//  SearchProductRequest.swift
+//
+//
+//  Created by 김응철 on 3/2/24.
+//
+
+import Entity
+import Foundation
+
+public struct SearchProductRequest: Encodable {
+  public let name: String
+  public let order: Order
+  public let pageSize: Int
+  public let offset: Int
+
+  enum CodingKeys: String, CodingKey {
+    case name = "product_name"
+    case order
+    case pageSize
+    case offset
+  }
+
+  public init(name: String, order: Order, pageSize: Int, offset: Int) {
+    self.name = name
+    self.order = order
+    self.pageSize = pageSize
+    self.offset = offset
+  }
+}

--- a/APIService/Sources/SearchAPI/Responses/SearchProductResponse.swift
+++ b/APIService/Sources/SearchAPI/Responses/SearchProductResponse.swift
@@ -1,0 +1,46 @@
+//
+//  SearchProductResponse.swift
+//
+//
+//  Created by 김응철 on 3/2/24.
+//
+
+import Entity
+import Foundation
+
+// MARK: - SearchProductResponse
+
+struct SearchProductResponse: Decodable, Paginatable {
+  let count: Int
+  let hasMore: Bool
+
+  let results: [SearchProductItemResponse]
+
+  enum CodingKeys: String, CodingKey {
+    case count
+    case hasMore = "has_more"
+    case results
+  }
+}
+
+// MARK: - SearchProductItemResponse
+
+struct SearchProductItemResponse: Decodable {
+  let id: Int
+  let imageURL: URL?
+  let date: Date
+  let price: Int
+  let name: String
+  let promotion: Promotion
+  let convenienceStore: ConvenienceStore
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case imageURL = "img"
+    case price
+    case date
+    case name
+    case promotion = "tag"
+    case convenienceStore = "store"
+  }
+}

--- a/APIService/Sources/SearchAPI/SearchEndPoint.swift
+++ b/APIService/Sources/SearchAPI/SearchEndPoint.swift
@@ -1,0 +1,41 @@
+//
+//  SearchEndPoint.swift
+//
+//
+//  Created by 김응철 on 3/2/24.
+//
+
+import Foundation
+import Network
+
+// MARK: - SearchEndPoint
+
+public enum SearchEndPoint {
+  case fetchProducts(SearchProductRequest)
+}
+
+// MARK: EndPoint
+
+extension SearchEndPoint: EndPoint {
+  public var method: HTTPMethod {
+    .get
+  }
+
+  public var path: String {
+    switch self {
+    case .fetchProducts:
+      "/v2/search"
+    }
+  }
+
+  public var parameters: HTTPParameter {
+    switch self {
+    case let .fetchProducts(requestModel):
+      .query(requestModel)
+    }
+  }
+
+  public var headers: [String: String] {
+    ["Content-Type": "application/json"]
+  }
+}

--- a/APIService/Sources/SearchAPI/SearchService.swift
+++ b/APIService/Sources/SearchAPI/SearchService.swift
@@ -1,0 +1,60 @@
+//
+//  SearchService.swift
+//
+//
+//  Created by 김응철 on 3/2/24.
+//
+
+import Entity
+import Foundation
+import Network
+
+// MARK: - SearchServiceRepresentable
+
+public protocol SearchServiceRepresentable {
+  func fetchSearchList(request: SearchProductRequest) async throws -> Paginated<SearchProduct>
+}
+
+// MARK: - SearchService
+
+public struct SearchService {
+  private let network: Networking
+
+  public init(network: Networking) {
+    self.network = network
+  }
+}
+
+// MARK: SearchServiceRepresentable
+
+extension SearchService: SearchServiceRepresentable {
+  public func fetchSearchList(request: SearchProductRequest) async throws -> Paginated<SearchProduct> {
+    let response: SearchProductResponse = try await network.request(
+      with: SearchEndPoint.fetchProducts(request)
+    )
+    return Paginated<SearchProduct>(dto: response)
+  }
+}
+
+private extension Paginated where Model == SearchProduct {
+  init(dto: SearchProductResponse) {
+    self.init(
+      count: dto.count,
+      hasMore: dto.hasMore,
+      results: dto.results.map(SearchProduct.init)
+    )
+  }
+}
+
+private extension SearchProduct {
+  init(dto: SearchProductItemResponse) {
+    self.init(
+      id: dto.id,
+      imageURL: dto.imageURL,
+      price: dto.price,
+      name: dto.name,
+      promotion: dto.promotion,
+      convenienceStore: dto.convenienceStore
+    )
+  }
+}

--- a/APIService/Sources/SearchAPISupport/Mocks/SearchProductResponse.json
+++ b/APIService/Sources/SearchAPISupport/Mocks/SearchProductResponse.json
@@ -1,0 +1,36 @@
+{
+  "count": 3,
+  "has_more": false,
+  "results": [
+    {
+      "name": "칠성)펩시콜라제로355ml",
+      "img": "https://www.7-eleven.co.kr/upload/product/8801056/175900.1.jpg",
+      "price": 1900,
+      "store": "7-ELEVEn",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 84462
+    },
+    {
+      "name": "롯데)펩시콜라캔355ML",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8801056150013_007.jpg",
+      "price": 1900,
+      "store": "GS25",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81629
+    },
+    {
+      "name": "칠성)펩시콜라제로355ml",
+      "img": "https://www.ministop.co.kr/MiniStopHomePage/page/pic.do?n=event1plus1.[YOUXY1LS_]1plus1_160.jpg",
+      "price": 1900,
+      "store": "MINISTOP",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 85911
+    }
+  ]
+}

--- a/APIService/Sources/SearchAPISupport/SearchURLProtocol.swift
+++ b/APIService/Sources/SearchAPISupport/SearchURLProtocol.swift
@@ -1,0 +1,49 @@
+//
+//  SearchURLProtocol.swift
+//
+//
+//  Created by 김응철 on 3/2/24.
+//
+
+import Foundation
+import Network
+import SearchAPI
+
+public final class SearchURLProtocol: URLProtocol {
+  private lazy var mockData: [String: Data?] = [
+    SearchEndPoint.fetchProducts(
+      SearchProductRequest(name: "칠성)펩시콜라제로355ml", order: .normal, pageSize: 0, offset: 0)
+    ).path: loadMockData(fileName: "SearchProductResponse"),
+  ]
+
+  override public class func canInit(with _: URLRequest) -> Bool {
+    true
+  }
+
+  override public class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  override public func startLoading() {
+    defer { client?.urlProtocolDidFinishLoading(self) }
+    if let url = request.url,
+       let mockData = mockData[url.path(percentEncoded: true)],
+       let data = mockData,
+       let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil) {
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      client?.urlProtocol(self, didLoad: data)
+    } else {
+      client?.urlProtocol(self, didFailWithError: NetworkError.urlError)
+    }
+  }
+
+  override public func stopLoading() {}
+
+  private func loadMockData(fileName: String) -> Data? {
+    guard let url = Bundle.module.url(forResource: fileName, withExtension: "json")
+    else {
+      return nil
+    }
+    return try? Data(contentsOf: url)
+  }
+}

--- a/Entity/Sources/Entity/SearchProduct.swift
+++ b/Entity/Sources/Entity/SearchProduct.swift
@@ -1,0 +1,45 @@
+//
+//  SearchProduct.swift
+//
+//
+//  Created by 김응철 on 3/2/24.
+//
+
+import Foundation
+
+/// 상품 검색 결과 리스트에 대한 Entity Model입니다.
+public struct SearchProduct: Identifiable {
+  /// 제품 고유 Identifier
+  public let id: Int
+
+  /// 이미지 URL
+  public let imageURL: URL?
+
+  /// 제품 가격
+  public let price: Int
+
+  /// 제품명
+  public let name: String
+
+  /// 행사 정보
+  public let promotion: Promotion
+
+  /// 편의점
+  public let convenienceStore: ConvenienceStore
+
+  public init(
+    id: Int,
+    imageURL: URL?,
+    price: Int,
+    name: String,
+    promotion: Promotion,
+    convenienceStore: ConvenienceStore
+  ) {
+    self.id = id
+    self.imageURL = imageURL
+    self.price = price
+    self.name = name
+    self.promotion = promotion
+    self.convenienceStore = convenienceStore
+  }
+}

--- a/PyeonHaeng-iOS.xcodeproj/project.pbxproj
+++ b/PyeonHaeng-iOS.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		E50584532B763C8C002FDACF /* ProductInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50584522B763C8C002FDACF /* ProductInfoViewModel.swift */; };
 		E5462C662B65677B00E9FDF2 /* PromotionTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5462C652B65677B00E9FDF2 /* PromotionTag.swift */; };
 		E55DD5122B91DE9500AA63C0 /* SearchListCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E55DD5112B91DE9500AA63C0 /* SearchListCardView.swift */; };
+		E55DD5182B9370D100AA63C0 /* SearchAPI in Frameworks */ = {isa = PBXBuildFile; productRef = E55DD5172B9370D100AA63C0 /* SearchAPI */; };
+		E55DD51A2B9370D100AA63C0 /* SearchAPISupport in Frameworks */ = {isa = PBXBuildFile; productRef = E55DD5192B9370D100AA63C0 /* SearchAPISupport */; };
 		E57654D92B90D78900E92F3A /* Shared in Resources */ = {isa = PBXBuildFile; fileRef = BABFEA6F2B6399C30084C0EC /* Shared */; };
 		E57F2AA42B7717EA00E12B3D /* ProductInfoAPI in Frameworks */ = {isa = PBXBuildFile; productRef = E57F2AA32B7717EA00E12B3D /* ProductInfoAPI */; settings = {ATTRIBUTES = (Required, ); }; };
 		E57F2AA62B7717EA00E12B3D /* ProductInfoAPISupport in Frameworks */ = {isa = PBXBuildFile; productRef = E57F2AA52B7717EA00E12B3D /* ProductInfoAPISupport */; };
@@ -112,6 +114,7 @@
 		E50584522B763C8C002FDACF /* ProductInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInfoViewModel.swift; sourceTree = "<group>"; };
 		E5462C652B65677B00E9FDF2 /* PromotionTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionTag.swift; sourceTree = "<group>"; };
 		E55DD5112B91DE9500AA63C0 /* SearchListCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchListCardView.swift; sourceTree = "<group>"; };
+		E55DD5152B936DD200AA63C0 /* SearchAPI */ = {isa = PBXFileReference; lastKnownFileType = folder; name = SearchAPI; path = APIService/Sources/SearchAPI; sourceTree = "<group>"; };
 		E57F2AA72B774CA700E12B3D /* ProductInfoDependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInfoDependency.swift; sourceTree = "<group>"; };
 		E5F2EC3F2B637D4A00EE0838 /* ProductInfoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInfoDetailView.swift; sourceTree = "<group>"; };
 		E5F2EC442B64926100EE0838 /* PromotionTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionTagView.swift; sourceTree = "<group>"; };
@@ -137,6 +140,8 @@
 				BA0623D82B68E51400A0A3B2 /* Log in Frameworks */,
 				BA0564092B6248EA003D6DC7 /* HomeAPI in Frameworks */,
 				BAB569612B639F3000D1E0F9 /* DesignSystem in Frameworks */,
+				E55DD5182B9370D100AA63C0 /* SearchAPI in Frameworks */,
+				E55DD51A2B9370D100AA63C0 /* SearchAPISupport in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -155,6 +160,7 @@
 		BA0564072B6248EA003D6DC7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E55DD5152B936DD200AA63C0 /* SearchAPI */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -409,6 +415,8 @@
 				BA4EA35F2B6A37E10003DCE7 /* Entity */,
 				E57F2AA32B7717EA00E12B3D /* ProductInfoAPI */,
 				E57F2AA52B7717EA00E12B3D /* ProductInfoAPISupport */,
+				E55DD5172B9370D100AA63C0 /* SearchAPI */,
+				E55DD5192B9370D100AA63C0 /* SearchAPISupport */,
 			);
 			productName = "PyeonHaeng-iOS";
 			productReference = BAA4D9A92B5A1795005999F8 /* PyeonHaeng-iOS.app */;
@@ -861,6 +869,14 @@
 		BAB569602B639F3000D1E0F9 /* DesignSystem */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = DesignSystem;
+		};
+		E55DD5172B9370D100AA63C0 /* SearchAPI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SearchAPI;
+		};
+		E55DD5192B9370D100AA63C0 /* SearchAPISupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SearchAPISupport;
 		};
 		E57F2AA32B7717EA00E12B3D /* ProductInfoAPI */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
## 고민, 과정, 근거 💬

- `SearchAPI` 관련한 필요한 코드들을 추가했습니다.
- `HomeAPI`와 똑같은 `DTO`, `Entity`를 사용할 수도 있었지만, 나중을 대비해서 Search구조체를 따로 만들었습니다.
- API가 전체적으로 구조가 비슷해서 `Home`, `ProductInfo`와 큰 차이가 없습니다.

---

- Closed: #72 