### PR TITLE
프로모션 눌렀을 때 UI 변경 / `+` 인코딩 이슈 해결 / DesignSystem의 primary 색상명 변경

### DIFF
--- a/Core/Sources/Network/NetworkProvider.swift
+++ b/Core/Sources/Network/NetworkProvider.swift
@@ -41,7 +41,7 @@ public struct NetworkProvider: Networking {
       case let .query(data):
         var components = URLComponents(string: url.absoluteString)
         components?.queryItems = data.toDictionary.map { URLQueryItem(name: $0, value: "\($1)") }
-        request.url = components?.url
+        request.url = URL(string: components?.url?.absoluteString.replacingOccurrences(of: "+", with: "%2B") ?? "")
       }
     } catch {
       throw NetworkError.encodeError

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductDetailSelectionView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductDetailSelectionView.swift
@@ -56,7 +56,7 @@ struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeView
           .renderingMode(.template)
       }
       .frame(height: Metrics.textHeight)
-      .foregroundStyle(.gray400)
+      .foregroundStyle(viewModel.state.productConfiguration.promotion == .allItems ? .gray400 : .white)
       .padding(
         .init(
           top: Metrics.promotionButtonPaddingTop,
@@ -67,10 +67,13 @@ struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeView
       )
     }
     .accessibilityHint("더블 탭하여 할인 조건을 선택하세요")
+    .background(
+      RoundedRectangle(cornerRadius: Metrics.promotionButtonCornerRadius)
+        .fill(viewModel.state.productConfiguration.promotion == .allItems ? .clear : .pyeonHaengPrimary)
+    )
     .overlay {
       RoundedRectangle(cornerRadius: Metrics.promotionButtonCornerRadius)
-        .stroke()
-        .foregroundStyle(.gray400)
+        .stroke(viewModel.state.productConfiguration.promotion == .allItems ? .gray400 : .clear)
     }
     .sheet(isPresented: $promotionModalPresented) {
       PromotionSelectBottomSheetView<ViewModel>()

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductDetailSelectionView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductDetailSelectionView.swift
@@ -17,63 +17,69 @@ struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeView
 
   var body: some View {
     HStack {
-      Button {
-        convenienceStoreModalPresented = true
-      } label: {
-        Group {
-          convenienceImageView()
-            .resizable()
-            .scaledToFit()
-          Image.chevronDown
-            .renderingMode(.template)
-            .foregroundStyle(.gray300)
-            .accessibilityHidden(true)
-        }
-      }
-      .accessibilityHint("더블 탭하여 편의점을 선택하세요")
-      .sheet(isPresented: $convenienceStoreModalPresented) {
-        ConvenienceSelectBottomSheetView<ViewModel>()
-          .presentationDetents([.height(Metrics.convenienceBottomSheetHeight)])
-          .presentationCornerRadius(20)
-          .presentationBackground(.regularMaterial)
-      }
-
+      convenienceStoreButton
       Spacer()
-
-      Button {
-        promotionModalPresented = true
-      } label: {
-        HStack(spacing: Metrics.buttonSpacing) {
-          Text(verbatim: "All")
-            .font(.title2)
-          Image.arrowTriangleDownFill
-            .renderingMode(.template)
-        }
-        .frame(height: Metrics.textHeight)
-        .foregroundStyle(.gray400)
-        .padding(
-          .init(
-            top: Metrics.promotionButtonPaddingTop,
-            leading: Metrics.promotionButtonPaddingLeading,
-            bottom: Metrics.promotionButtonPaddingBottom,
-            trailing: Metrics.promotionButtonPaddingTrailing
-          )
-        )
-      }
-      .accessibilityHint("더블 탭하여 할인 조건을 선택하세요")
-      .overlay {
-        RoundedRectangle(cornerRadius: Metrics.promotionButtonCornerRadius)
-          .stroke()
-          .foregroundStyle(.gray400)
-      }
-      .sheet(isPresented: $promotionModalPresented) {
-        PromotionSelectBottomSheetView<ViewModel>()
-          .presentationDetents([.height(Metrics.promotionBottomSheetHeight)])
-          .presentationCornerRadius(20)
-          .presentationBackground(.regularMaterial)
-      }
+      promotionButton
     }
     .frame(height: Metrics.height)
+  }
+
+  private var convenienceStoreButton: some View {
+    Button {
+      convenienceStoreModalPresented = true
+    } label: {
+      Group {
+        convenienceImageView()
+          .resizable()
+          .scaledToFit()
+        Image.chevronDown
+          .renderingMode(.template)
+          .foregroundStyle(.gray300)
+          .accessibilityHidden(true)
+      }
+    }
+    .accessibilityHint("더블 탭하여 편의점을 선택하세요")
+    .sheet(isPresented: $convenienceStoreModalPresented) {
+      ConvenienceSelectBottomSheetView<ViewModel>()
+        .presentationDetents([.height(Metrics.convenienceBottomSheetHeight)])
+        .presentationCornerRadius(20)
+        .presentationBackground(.regularMaterial)
+    }
+  }
+
+  private var promotionButton: some View {
+    Button {
+      promotionModalPresented = true
+    } label: {
+      HStack(spacing: Metrics.buttonSpacing) {
+        Text(verbatim: viewModel.state.productConfiguration.promotion.rawValue)
+          .font(.title2)
+        Image.arrowTriangleDownFill
+          .renderingMode(.template)
+      }
+      .frame(height: Metrics.textHeight)
+      .foregroundStyle(.gray400)
+      .padding(
+        .init(
+          top: Metrics.promotionButtonPaddingTop,
+          leading: Metrics.promotionButtonPaddingLeading,
+          bottom: Metrics.promotionButtonPaddingBottom,
+          trailing: Metrics.promotionButtonPaddingTrailing
+        )
+      )
+    }
+    .accessibilityHint("더블 탭하여 할인 조건을 선택하세요")
+    .overlay {
+      RoundedRectangle(cornerRadius: Metrics.promotionButtonCornerRadius)
+        .stroke()
+        .foregroundStyle(.gray400)
+    }
+    .sheet(isPresented: $promotionModalPresented) {
+      PromotionSelectBottomSheetView<ViewModel>()
+        .presentationDetents([.height(Metrics.promotionBottomSheetHeight)])
+        .presentationCornerRadius(20)
+        .presentationBackground(.regularMaterial)
+    }
   }
 
   private func convenienceImageView() -> Image {

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductDetailSelectionView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductDetailSelectionView.swift
@@ -41,9 +41,7 @@ struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeView
     .accessibilityHint("더블 탭하여 편의점을 선택하세요")
     .sheet(isPresented: $convenienceStoreModalPresented) {
       ConvenienceSelectBottomSheetView<ViewModel>()
-        .presentationDetents([.height(Metrics.convenienceBottomSheetHeight)])
-        .presentationCornerRadius(20)
-        .presentationBackground(.regularMaterial)
+        .bottomSheetPresentation(height: Metrics.convenienceBottomSheetHeight)
     }
   }
 
@@ -76,9 +74,7 @@ struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeView
     }
     .sheet(isPresented: $promotionModalPresented) {
       PromotionSelectBottomSheetView<ViewModel>()
-        .presentationDetents([.height(Metrics.promotionBottomSheetHeight)])
-        .presentationCornerRadius(20)
-        .presentationBackground(.regularMaterial)
+        .bottomSheetPresentation(height: Metrics.promotionBottomSheetHeight)
     }
   }
 
@@ -95,6 +91,14 @@ struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeView
     case .ministop:
       .ministop
     }
+  }
+}
+
+extension View {
+  func bottomSheetPresentation(height: CGFloat) -> some View {
+    presentationDetents([.height(height)])
+      .presentationCornerRadius(20)
+      .presentationBackground(.regularMaterial)
   }
 }
 

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductSorterView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductSorterView.swift
@@ -38,7 +38,7 @@ private extension HomeProductSorterView {
     var string = AttributedString(localized: "총 \(viewModel.state.totalCount)개의 상품이 있어요!")
 
     if let range = string.range(of: "\(viewModel.state.totalCount.formatted())") {
-      string[range].foregroundColor = .green500
+      string[range].foregroundColor = .pyeonHaengPrimary
     }
 
     return string
@@ -61,7 +61,7 @@ private extension HomeProductSorterView {
       .gray200
     case .ascending,
          .descending:
-      .green500
+      .pyeonHaengPrimary
     }
   }
 

--- a/Shared/Sources/DesignSystem/Sources/Extensions/ShapeStyle+Color.swift
+++ b/Shared/Sources/DesignSystem/Sources/Extensions/ShapeStyle+Color.swift
@@ -78,5 +78,5 @@ public extension ShapeStyle where Self == Color {
 
   // Semantic Colors
 
-  static var primary: Color { .green500 }
+  static var pyeonHaengPrimary: Color { .green500 }
 }


### PR DESCRIPTION
## Screenshots 📸

|적용 영상|
|:-:|
|![RPReplay_Final1709536612 2](https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/5fd7fc3a-a08c-4a52-a3a8-8ba624e6b571)|

<br/><br/>

## 고민, 과정, 근거 💬

### 네트워크 인코딩

`+`기호를 URL에서 사용하기 위해 `%2B`로 변경했습니다.<sup>[[1]](#ref1)</sup> `+`는 URL에서 직접 사용할 수 없어서 UTF-8문자로 변환해야합니다.
`URLQueryItem`을 생성할 때 같이 인코딩해서 넣어주면 될 줄 알았지만, request에 url을 넣을 때 로깅을 확인한 결과, `%2B`에서 `%`자체를 또 `UTF-8`로 변환해서 최종적으로 **`%252B`** 가 들어가는 현상을 발견했습니다. 그래서 마지막에 `request.url`을 초기화하기 전에, `+`기호를 인코딩한 `URL String` 가지고 `URL`을 다시 새롭게 생성하는 방법으로 해결했습니다.

### UI 수정

SwiftUI에서도 `primary`라는 색상이 존재하기에, `DesignSystem`과 겹치는 경우가 발생했습니다. 그래서 기존 DesignSystem의 `primary`색상을 `pyeonHaengPrimary`로 변경했습니다.
최대한 `PyeonHaeng`명을 안쓰고 싶지만 ㅎㅎ.. 이거 외에 떠오르는 변수명이 없었습니다.

<br/><br/>

## References 📋


1. <a id="ref1">[HTML URL Encoding Reference](https://www.w3schools.com/tags/ref_urlencode.ASP)</a>

<br/><br/>

---

- Closed: #79
