### PR TITLE
다운샘플링과 캐싱을 지원하는 `CachedAsyncImage` 구현

### DIFF
--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductListView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductListView.swift
@@ -73,7 +73,13 @@ private struct ProductImageView: View {
   }
 
   var body: some View {
-    AsyncImage(url: product.imageURL) { phase in
+    CachedAsyncImage(
+      url: product.imageURL,
+      downsampleSize: .init(
+        width: Metrics.originalImageSize,
+        height: Metrics.originalImageSize
+      )
+    ) { phase in
       if let image = phase.image {
         image
           .resizable()

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
@@ -29,7 +29,7 @@ private struct ImageView: View {
   let product: DetailProduct
 
   var body: some View {
-    AsyncImage(url: product.imageURL) { image in
+    CachedAsyncImage(url: product.imageURL) { image in
       image
         .resizable()
         .scaledToFit()

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchListCardView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchListCardView.swift
@@ -5,6 +5,7 @@
 //  Created by 김응철 on 3/1/24.
 //
 
+import DesignSystem
 import Entity
 import SwiftUI
 
@@ -29,7 +30,7 @@ private struct SearchImageView: View {
   let product: SearchProduct
 
   var body: some View {
-    AsyncImage(url: product.imageURL) { phase in
+    CachedAsyncImage(url: product.imageURL) { phase in
       if let image = phase.image {
         image
           .resizable()

--- a/Shared/Sources/DesignSystem/Components/Images/CachedAsyncImage.swift
+++ b/Shared/Sources/DesignSystem/Components/Images/CachedAsyncImage.swift
@@ -50,7 +50,7 @@ public struct CachedAsyncImage<Content: View>: View {
 
   public init(
     url: URL?,
-    urlCache: URLCache,
+    urlCache: URLCache = .imageCache,
     scale: CGFloat = 1,
     downsampleSize: CGSize? = nil,
     transaction: Transaction = Transaction(),

--- a/Shared/Sources/DesignSystem/Components/Images/CachedAsyncImage.swift
+++ b/Shared/Sources/DesignSystem/Components/Images/CachedAsyncImage.swift
@@ -1,0 +1,167 @@
+//
+//  CachedAsyncImage.swift
+//
+//
+//  Created by 홍승현 on 3/6/24.
+//
+
+import SwiftUI
+
+// MARK: - CachedAsyncImage
+
+public struct CachedAsyncImage<Content: View>: View {
+  @State private var phase: AsyncImagePhase
+  private let content: (AsyncImagePhase) -> Content
+  private let transaction: Transaction
+  private let scale: CGFloat
+  private let urlSession: URLSession
+  private let urlRequest: URLRequest?
+
+  public init(
+    url: URL?,
+    urlCache: URLCache = .imageCache,
+    scale: CGFloat = 1
+  ) where Content == Image {
+    self.init(url: url, urlCache: urlCache, scale: scale) { phase in
+      phase.image ?? Image(uiImage: .init())
+    }
+  }
+
+  public init<I, P>(
+    url: URL?,
+    urlCache: URLCache = .imageCache,
+    scale: CGFloat = 1,
+    @ViewBuilder content: @escaping (Image) -> I,
+    @ViewBuilder placeholder: @escaping () -> P
+  ) where Content == _ConditionalContent<I, P>, I: View, P: View {
+    self.init(url: url, urlCache: urlCache, scale: scale) { phase in
+      if let image = phase.image {
+        content(image)
+      } else {
+        placeholder()
+      }
+    }
+  }
+
+  public init(
+    url: URL?,
+    urlCache: URLCache,
+    scale: CGFloat = 1,
+    transaction: Transaction = Transaction(),
+    @ViewBuilder content: @escaping (AsyncImagePhase) -> Content
+  ) {
+    let urlRequest: URLRequest? = if let url { URLRequest(url: url) } else { nil }
+    let configuration: URLSessionConfiguration = .default
+    configuration.urlCache = urlCache
+    urlSession = URLSession(configuration: configuration)
+    self.urlRequest = urlRequest
+    self.content = content
+    self.scale = scale
+    self.transaction = transaction
+
+    _phase = State(wrappedValue: .empty)
+
+    // 캐싱 이미지가 있다면 phase를 success로 설정
+    do {
+      if let urlRequest,
+         let image = try cachedImage(from: urlRequest, cache: urlCache) {
+        _phase = State(wrappedValue: .success(image))
+      }
+    } catch {
+      // 이미지 호출 플로우에 에러가 발생
+      _phase = State(wrappedValue: .failure(error))
+    }
+  }
+
+  public var body: some View {
+    content(phase)
+      .task(id: urlRequest, load)
+  }
+
+  @Sendable
+  private func load() async {
+    do {
+      guard let urlRequest
+      else {
+        withAnimation(transaction.animation) {
+          phase = .empty
+        }
+        return
+      }
+
+      let (image, metrics) = try await remoteImage(from: urlRequest, session: urlSession)
+      if metrics.transactionMetrics.last?.resourceFetchType == .localCache {
+        phase = .success(image)
+      } else {
+        withAnimation(transaction.animation) {
+          phase = .success(image)
+        }
+      }
+
+    } catch {
+      withAnimation(transaction.animation) {
+        phase = .failure(error)
+      }
+    }
+  }
+}
+
+// MARK: CachedAsyncImage.LoadingError
+
+private extension CachedAsyncImage {
+  struct LoadingError: Error {}
+}
+
+// MARK: - Caching Part
+
+private extension CachedAsyncImage {
+  func remoteImage(from request: URLRequest, session: URLSession) async throws -> (Image, URLSessionTaskMetrics) {
+    let controller = SessionController()
+
+    let (data, _) = try await session.data(for: request, delegate: controller)
+    let metrics = controller.metrics!
+
+    if metrics.redirectCount > 0,
+       let lastResponse = metrics.transactionMetrics.last?.response {
+      let requests = metrics.transactionMetrics.map(\.request)
+      requests.forEach(session.configuration.urlCache!.removeCachedResponse(for:))
+      let lastCachedResponse = CachedURLResponse(response: lastResponse, data: data)
+      session.configuration.urlCache!.storeCachedResponse(lastCachedResponse, for: request)
+    }
+
+    return try (image(from: data), metrics)
+  }
+
+  /// URL로 캐싱되어있는 데이터가 있다면 이미지로 불러옵니다.
+  func cachedImage(from request: URLRequest, cache: URLCache) throws -> Image? {
+    guard let cachedResponse = cache.cachedResponse(for: request) else { return nil }
+    return try image(from: cachedResponse.data)
+  }
+
+  /// data타입을 Image타입으로 변환합니다. 만약 image로 가져올 수 없다면 Error를 내보냅니다.
+  /// - Parameter data: Image data
+  func image(from data: Data) throws -> Image {
+    if let uiImage = UIImage(data: data, scale: scale) {
+      return Image(uiImage: uiImage)
+    } else {
+      throw LoadingError()
+    }
+  }
+}
+
+// MARK: - SessionController
+
+private class SessionController: NSObject, URLSessionTaskDelegate {
+  var metrics: URLSessionTaskMetrics?
+
+  func urlSession(_: URLSession, task _: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+    self.metrics = metrics
+  }
+}
+
+public extension URLCache {
+  static let imageCache = URLCache(
+    memoryCapacity: 10_000_000, // ~10MB bytes memory space
+    diskCapacity: 1_000_000_000 // ~1GB disk cache space
+  )
+}


### PR DESCRIPTION
> [!Note]
>
> 브랜치명을 잘못설정했네요. 😅

## Screenshots 📸

|캐시 miss & hit 화면|
|:-:|
|![Screen Recording 2024-03-07 at 3 22 41 PM](https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/e87580e4-f78f-4d33-be84-e6388fdc1074)|


|캐싱 전|캐싱 후|
|:-:|:-:|
|![Screen Recording 2024-03-07 at 5 01 51 PM](https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/90e8f105-50f1-4704-953e-4195f9b2f1f2)|![Screen Recording 2024-03-07 at 5 03 20 PM](https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/b87f57ee-8dfa-49fc-be3c-8fce46ff2025)|

<br/><br/>

## 고민, 과정, 근거 💬

- 네트워킹 비용을 줄이고자 URLCache를 활용한 `CachedAsyncImage`를 구현했습니다. 근데 이미지를 각각 다운로드 하는 과정에서 스레드가 생기다보니 `Thread Explosion`문제가 좀 걸리기는 합니다. SerialQueue를 하나 만들어서 그 큐 내에서 동작시키도록 하는 방법이 없나 모색중입니다!
- 캐싱을 하게 되면 메모리가 증가되는 걸 보실 수 있는데, 당연한 거예요! 서버로부터 다운받은 이미지를 캐싱하는 거니까요 :)
- 편의점 사이트에서 다운샘플링을 이미 해둔 상태더라고요. 큰 메리트가 있는 건 아니지만, 70x70사이즈로 보여줄 데이터를 해상도 높게 보여줄 필요가 없으므로 DownSampling도 구현해두었습니다.

<br/><br/>

## References 📋

1. [How Does Swift Concurrency Prevent Thread Explosions?](https://swiftsenpai.com/swift/swift-concurrency-prevent-thread-explosion)
2. [WWDC18 Image and Graphics Best Practices](https://docs.huihoo.com/apple/wwdc/2018/219_image_and_graphics_best_practices.pdf)

<br/><br/>

---

- Closed: #85 
