### PR TITLE
설정 화면 - 공지 화면 구현

### DIFF
--- a/PyeonHaeng-iOS.xcodeproj/project.pbxproj
+++ b/PyeonHaeng-iOS.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		BA05640B2B6248EA003D6DC7 /* HomeAPISupport in Frameworks */ = {isa = PBXBuildFile; productRef = BA05640A2B6248EA003D6DC7 /* HomeAPISupport */; };
 		BA05640D2B6248EA003D6DC7 /* Network in Frameworks */ = {isa = PBXBuildFile; productRef = BA05640C2B6248EA003D6DC7 /* Network */; };
 		BA0623D82B68E51400A0A3B2 /* Log in Frameworks */ = {isa = PBXBuildFile; productRef = BA0623D72B68E51400A0A3B2 /* Log */; };
+		BA1688E02B99B85500A8F462 /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1688DF2B99B85500A8F462 /* NoticeView.swift */; };
 		BA28F17C2B6155450052855E /* PyeonHaeng_iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA28F17B2B6155450052855E /* PyeonHaeng_iOSTests.swift */; };
 		BA28F1852B6155810052855E /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA28F1842B6155810052855E /* OnboardingView.swift */; };
 		BA28F1882B6155910052855E /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA28F1872B6155910052855E /* HomeView.swift */; };
@@ -80,6 +81,7 @@
 		BA0564022B62179A003D6DC7 /* Core */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Core; sourceTree = "<group>"; };
 		BA0564032B6219D4003D6DC7 /* APIService */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = APIService; sourceTree = "<group>"; };
 		BA0564052B624646003D6DC7 /* Shared.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Shared.xcconfig; path = XCConfig/Shared.xcconfig; sourceTree = SOURCE_ROOT; };
+		BA1688DF2B99B85500A8F462 /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
 		BA28F1792B6155450052855E /* PyeonHaeng-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "PyeonHaeng-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA28F17B2B6155450052855E /* PyeonHaeng_iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PyeonHaeng_iOSTests.swift; sourceTree = "<group>"; };
 		BA28F1842B6155810052855E /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -171,6 +173,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		BA1688EB2B99D0B700A8F462 /* Notice */ = {
+			isa = PBXGroup;
+			children = (
+				BA1688DF2B99B85500A8F462 /* NoticeView.swift */,
+			);
+			path = Notice;
+			sourceTree = "<group>";
+		};
 		BA28F1702B6152E90052855E /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -260,6 +270,7 @@
 		BA28F18C2B6155EC0052855E /* SettingsScene */ = {
 			isa = PBXGroup;
 			children = (
+				BA1688EB2B99D0B700A8F462 /* Notice */,
 				BA28F18D2B6156420052855E /* SettingsView.swift */,
 			);
 			path = SettingsScene;
@@ -578,6 +589,7 @@
 				9CE4B4712B6F0B57002DC446 /* OnboardingPage.swift in Sources */,
 				E52F371B2B947DC8000EBAD5 /* SearchViewModel.swift in Sources */,
 				BAE159DE2B663A9A002DCF94 /* HomeProductSorterView.swift in Sources */,
+				BA1688E02B99B85500A8F462 /* NoticeView.swift in Sources */,
 				BAE159D82B65FA6F002DCF94 /* HomeProductDetailSelectionView.swift in Sources */,
 				E50176262B6A204F0098D1BE /* ProductInfoLineGraphView.swift in Sources */,
 				BAB5CF252B6B7C5A008B24BF /* AppRootComponent.swift in Sources */,

--- a/PyeonHaeng-iOS/Sources/Scenes/SettingsScene/Notice/NoticeView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/SettingsScene/Notice/NoticeView.swift
@@ -1,0 +1,37 @@
+//
+//  NoticeView.swift
+//  PyeonHaeng-iOS
+//
+//  Created by 홍승현 on 3/7/24.
+//
+
+import DesignSystem
+import SwiftUI
+
+struct NoticeView: View {
+  var body: some View {
+    NavigationStack {
+      List(0 ..< 10) { _ in
+        VStack(alignment: .leading, spacing: 2) {
+          Text(verbatim: "2023.10.18")
+            .foregroundStyle(.gray200)
+            .font(.c4)
+          Text(verbatim: "프로토 타입 완성, 전기 자동차로 해양을 가로지르는 세계 최장 다리 건설 예정")
+            .lineLimit(1)
+            .foregroundStyle(.gray900)
+            .font(.body2)
+        }
+        .padding(.top, 8)
+        .padding(.bottom, 12)
+      }
+      .navigationTitle("Announcements")
+      .navigationBarTitleDisplayMode(.inline)
+      .listStyle(.plain)
+      .padding(.vertical, 8)
+    }
+  }
+}
+
+#Preview {
+  NoticeView()
+}

--- a/PyeonHaeng-iOS/Sources/Scenes/SettingsScene/SettingsView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/SettingsScene/SettingsView.swift
@@ -17,23 +17,6 @@ private enum SettingsItem: LocalizedStringKey, CaseIterable {
   case leaveReview = "Leave a Review"
   case versionInfo = "Version Info"
   case credits = "Credits"
-
-  var iconName: Image {
-    switch self {
-    case .notifications:
-      .bell
-    case .announcements:
-      .speaker
-    case .contacts:
-      .notePencil
-    case .leaveReview:
-      .appstore
-    case .versionInfo:
-      .infoCircle
-    case .credits:
-      .faceWinking
-    }
-  }
 }
 
 // MARK: - SettingsView
@@ -42,33 +25,7 @@ struct SettingsView: View {
   var body: some View {
     List {
       ForEach(SettingsItem.allCases, id: \.self) { item in
-        switch item {
-        case .notifications:
-          // TODO: 알림 설정 추가해야 합니다.
-          Toggle(isOn: .constant(false)) {
-            HStack {
-              item.iconName
-              Text(item.rawValue)
-            }
-          }
-
-        case .versionInfo:
-          HStack {
-            item.iconName
-            Text(item.rawValue)
-            Spacer()
-            Text(verbatim: .version ?? "-")
-              .font(.c2)
-          }
-
-        default:
-          HStack {
-            NavigationLink {} label: {
-              item.iconName
-              Text(item.rawValue)
-            }
-          }
-        }
+        SettingsRow(item: item)
       }
       .frame(height: Metrics.itemHeight)
       .padding(.vertical, Metrics.itemVerticalPadding)
@@ -84,6 +41,65 @@ struct SettingsView: View {
 private extension String {
   static var version: String? {
     Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+  }
+}
+
+// MARK: - SettingsRow
+
+private struct SettingsRow: View {
+  private let item: SettingsItem
+
+  init(item: SettingsItem) {
+    self.item = item
+  }
+
+  var body: some View {
+    switch item {
+    case .notifications:
+      // TODO: 알림 설정 추가해야 합니다.
+      Toggle(isOn: .constant(false)) {
+        subject
+      }
+
+    case .versionInfo:
+      HStack {
+        subject
+        Spacer()
+        Text(verbatim: .version ?? "-")
+          .font(.c2)
+      }
+
+    default:
+      NavigationLink {} label: {
+        subject
+      }
+    }
+  }
+
+  private var subject: some View {
+    HStack {
+      image(from: item)
+        .renderingMode(.template)
+        .foregroundStyle(.gray900)
+      Text(item.rawValue)
+    }
+  }
+
+  private func image(from item: SettingsItem) -> Image {
+    switch item {
+    case .notifications:
+      .bell
+    case .announcements:
+      .speaker
+    case .contacts:
+      .notePencil
+    case .leaveReview:
+      .appstore
+    case .versionInfo:
+      .infoCircle
+    case .credits:
+      .faceWinking
+    }
   }
 }
 

--- a/PyeonHaeng-iOS/Sources/Scenes/SettingsScene/SettingsView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/SettingsScene/SettingsView.swift
@@ -69,6 +69,14 @@ private struct SettingsRow: View {
           .font(.c2)
       }
 
+    case .announcements:
+      NavigationLink {
+        NoticeView()
+          .toolbarRole(.editor)
+      } label: {
+        subject
+      }
+
     default:
       NavigationLink {} label: {
         subject


### PR DESCRIPTION
## Screenshots 📸

|공지 화면|
|:-:|
|<img src="https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/e7399f5f-0f7e-4d64-90e7-d8e6d1333efe" width="30%"/>|

<br/><br/>

## 고민, 과정, 근거 💬

- 아직 다크모드 정리가 안되어있는 것 같아요. 색상이 너무 어둡네요..ㅎ
- SettingsView의 각 아이템들을 어떻게 정리해서 뷰를 그려줘야할까 고민입니다. enumeration을 사용하긴 했는데, 나중에 새로이 설정 옵션이 생기게 된다면 일일히 수정하는 게 번거로울 것 같아서 protocol을 이용한 방식을 생각해보았습니다만, 테스트하던 중 `associatedtype`에 막혀버렸습니다. 🥲 그래서 우선 롤백하고 기존 enumereation 그대로 사용했습니다.

<br/><br/>

---

- Closed: #87
