### PR TITLE
SearchView, 검색 실패 UI 및 코드 구조화, 버그 수정

### DIFF
--- a/APIService/Sources/SearchAPISupport/Mocks/SearchProductResponse.json
+++ b/APIService/Sources/SearchAPISupport/Mocks/SearchProductResponse.json
@@ -31,6 +31,176 @@
       "proinfo": 0,
       "date": "2024-02-01T00:00:00Z",
       "id": 85911
+    },
+    {
+      "name": "CJ)워터젤리복숭아130G",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8801007038032_035.jpg",
+      "price": 1900,
+      "store": "GS25",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81340
+    },
+    {
+      "name": "CJ)워터젤리오렌지130G",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8801007026275_278.jpg",
+      "price": 1900,
+      "store": "GS25",
+      "tag": "2+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81341
+    },
+    {
+      "name": "CJ)워터젤리포도130G",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8801007067285_002.jpg",
+      "price": 1900,
+      "store": "GS25",
+      "tag": "2+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81342
+    },
+    {
+      "name": "안동간고등어100G(순살/냉동)",
+      "img": "None",
+      "price": 5000,
+      "store": "GS25",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81343
+    },
+    {
+      "name": "노가리먹태1입",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8809677723586_002.jpg",
+      "price": 6900,
+      "store": "GS25",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81344
+    },
+    {
+      "name": "먹태랑오징어30G",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8809193858434_002.jpg",
+      "price": 6900,
+      "store": "GS25",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81345
+    },
+    {
+      "name": "먹태를찍먹30G",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8809193858250_004.jpg",
+      "price": 6900,
+      "store": "GS25",
+      "tag": "2+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81346
+    },
+    {
+      "name": "복태구이(40G/1미)",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8809465730147_001.jpg",
+      "price": 8500,
+      "store": "GS25",
+      "tag": "2+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81347
+    },
+    {
+      "name": "미닛메이드)레몬에이드제로350ML",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8801094326203_001.jpg",
+      "price": 1900,
+      "store": "GS25",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81348
+    },
+    {
+      "name": "현대)미에로화이바스파클링제로",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8806004000587_002.jpg",
+      "price": 2200,
+      "store": "GS25",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81349
+    },
+    {
+      "name": "빙그레)닥터캡슐베리믹스130ML",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8801104669283_001.jpg",
+      "price": 2200,
+      "store": "GS25",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81350
+    },
+    {
+      "name": "빙그레)닥터캡슐복분자130ML",
+      "img": "None",
+      "price": 2200,
+      "store": "GS25",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81351
+    },
+    {
+      "name": "빙그레)닥터캡슐사과130ML",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8801104665421_001.jpg",
+      "price": 2200,
+      "store": "GS25",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81352
+    },
+    {
+      "name": "빙그레)닥터캡슐프로텍트130ML",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8801104302739_004.jpg",
+      "price": 2200,
+      "store": "GS25",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81353
+    },
+    {
+      "name": "Y(P)명품갈비탕600G(냉장)",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8809396242689_001.JPG",
+      "price": 15900,
+      "store": "GS25",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81354
+    },
+    {
+      "name": "Y(P)명품염소전골500G(냉장)",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8809396242733_001.jpg",
+      "price": 15900,
+      "store": "emart24",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81355
+    },
+    {
+      "name": "꿀에빠진도라지말랭이15G",
+      "img": "https://image.woodongs.com/imgsvr/item/GD_8809742173049_001.jpg",
+      "price": 2500,
+      "store": "emart24",
+      "tag": "1+1",
+      "proinfo": 0,
+      "date": "2024-02-01T00:00:00Z",
+      "id": 81356
     }
   ]
 }

--- a/PyeonHaeng-iOS/Resources/Localizable.xcstrings
+++ b/PyeonHaeng-iOS/Resources/Localizable.xcstrings
@@ -40,6 +40,50 @@
         }
       }
     },
+    "• 검색어의 단어 수를 줄이거나," : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "• Reduce the number of search terms or,"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "• 検索語の数を減らすか、"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "검색어의 단어수를 줄이거나,"
+          }
+        }
+      }
+    },
+    "• 단어의 철자가 정확한지 확인해 보세요." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "• Please check if the word and spelling are accurate."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "• 単語とスペルが正確かどうかを確認してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "단어의 철자가 정확한지 확인해보세요."
+          }
+        }
+      }
+    },
     "1+1" : {
       "localizations" : {
         "ja" : {
@@ -370,6 +414,28 @@
         }
       }
     },
+    "검색 결과가 없어요." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No search results found."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "• 検索結果が見つかりません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "검색 결과가 없어요."
+          }
+        }
+      }
+    },
     "기본 정렬" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -680,6 +746,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "이전 행사 정보"
+          }
+        }
+      }
+    },
+    "일반적인 검색어로 다시 검색해 보세요." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try searching again with common keywords."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "一般的なキーワードで再検索してみてください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "일반적인 검색어로 다시 검색해 보세요."
           }
         }
       }

--- a/PyeonHaeng-iOS/Resources/Localizable.xcstrings
+++ b/PyeonHaeng-iOS/Resources/Localizable.xcstrings
@@ -782,13 +782,13 @@
         },
         "ja" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "一般的なキーワードで再検索してみてください。"
           }
         },
         "ko" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "일반적인 검색어로 다시 검색해 보세요."
           }
         }

--- a/PyeonHaeng-iOS/Resources/Localizable.xcstrings
+++ b/PyeonHaeng-iOS/Resources/Localizable.xcstrings
@@ -436,6 +436,28 @@
         }
       }
     },
+    "검색할 상품이름을 입력해주세요" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "enter the product name to search."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "検索する商品名を入力してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "검색할 상품이름을 입력해주세요."
+          }
+        }
+      }
+    },
     "기본 정렬" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchListCardView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchListCardView.swift
@@ -34,12 +34,13 @@ private struct SearchImageView: View {
       if let image = phase.image {
         image
           .resizable()
-          .scaledToFill()
+          .scaledToFit()
           .frame(width: Metrics.imageSize, height: Metrics.imageSize)
       } else if phase.error != nil {
         Image.textLogo
           .resizable()
-          .frame(width: 40, height: 30)
+          .scaledToFit()
+          .frame(width: Metrics.textLogoWidth, height: Metrics.textLogoHeight)
       } else {
         ProgressView()
       }
@@ -54,13 +55,13 @@ private struct SearchDetailView: View {
   let product: SearchProduct
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 8.0) {
+    VStack(alignment: .leading, spacing: Metrics.detailVStackSpacing) {
       PromotionTagView(promotion: product.promotion)
       Text(product.name)
         .font(.title1)
         .foregroundStyle(.gray900)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.bottom, 8.0)
+        .padding(.bottom, Metrics.detailVStackSpacing)
       HStack {
         Text("\(product.price.formatted())원")
           .font(.x2)
@@ -86,6 +87,10 @@ private enum Metrics {
 
   static let verticalPadding = 20.0
   static let horizontalPadding = 16.0
+  static let detailVStackSpacing = 8.0
+
+  static let textLogoWidth = 40.0
+  static let textLogoHeight = 30.0
 
   static let imageSize = 70.0
   static let totalImageSize = 96.0

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
@@ -13,6 +13,7 @@ import SwiftUI
 
 struct SearchView<ViewModel>: View where ViewModel: SearchViewModelRepresentable {
   @StateObject private var viewModel: ViewModel
+  @State private var text: String = ""
 
   init(viewModel: @autoclosure @escaping () -> ViewModel) {
     _viewModel = .init(wrappedValue: viewModel())
@@ -68,9 +69,10 @@ struct SearchView<ViewModel>: View where ViewModel: SearchViewModelRepresentable
     }
     .toolbar {
       ToolbarItem(placement: .principal) {
-        SearchTextField<ViewModel>()
+        SearchTextField<ViewModel>(text: $text)
       }
     }
+    .scrollDismissesKeyboard(.immediately)
     .environmentObject(viewModel)
   }
 }
@@ -78,12 +80,12 @@ struct SearchView<ViewModel>: View where ViewModel: SearchViewModelRepresentable
 // MARK: - SearchTextField
 
 private struct SearchTextField<ViewModel>: View where ViewModel: SearchViewModelRepresentable {
-  @State private var textInput: String = ""
+  @Binding var text: String
   @EnvironmentObject private var viewModel: ViewModel
 
   var body: some View {
     ZStack {
-      TextField(Metrics.placeholder, text: $textInput)
+      TextField(Metrics.placeholder, text: $text)
         .font(.b1)
         .frame(maxWidth: .infinity, maxHeight: Metrics.textFieldHeight)
         .padding(.vertical, Metrics.textFieldVerticalPadding)
@@ -92,13 +94,13 @@ private struct SearchTextField<ViewModel>: View where ViewModel: SearchViewModel
         .overlay {
           RoundedRectangle(cornerRadius: Metrics.cornerRadius)
             .stroke(
-              textInput.isEmpty ? Color.gray200 : Color.green500,
+              text.isEmpty ? Color.gray200 : Color.green500,
               lineWidth: Metrics.textFieldBorderWidth
             )
         }
-        .onSubmit { viewModel.trigger(.textChanged(textInput)) }
+        .onSubmit { viewModel.trigger(.textChanged(text)) }
       Button(action: {
-        textInput = ""
+        text = ""
       }) {
         Image.xCircleFill
           .renderingMode(.template)
@@ -155,6 +157,8 @@ private enum Metrics {
   static let textFieldHeight = 28.0
   static let textFieldBorderWidth = 1.0
   static let cornerRadius = 8.0
+
+  static let noSearchImageSize = 56.0
 
   static let horizontalPadding = 20.0
   static let headerTopPadding = 24.0

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
@@ -19,29 +19,53 @@ struct SearchView<ViewModel>: View where ViewModel: SearchViewModelRepresentable
   }
 
   var body: some View {
-    ScrollView {
-      LazyVStack(spacing: .zero) {
-        ForEach(Array(viewModel.state.products), id: \.key) { key, items in
-          Section {
-            ForEach(items) { item in
-              SearchListCardView(product: item)
+    Group {
+      if viewModel.state.isNothing {
+        Image.faceCrying
+          .resizable()
+          .renderingMode(.template)
+          .foregroundStyle(.gray400)
+          .frame(width: 56, height: 56)
+        Text("검색 결과가 없어요.")
+          .font(.title1)
+          .foregroundStyle(.gray400)
+        VStack(alignment: .leading) {
+          Text("• 단어의 철자가 정확한지 확인해 보세요.")
+          Text("• 검색어의 단어 수를 줄이거나,")
+          Text("일반적인 검색어로 다시 검색해 보세요.")
+            .padding(.leading, 10.0)
+        }
+        .font(.c3)
+        .foregroundStyle(.gray200)
+      } else {
+        ScrollView {
+          if viewModel.state.isNothing {
+          } else {
+            LazyVStack(spacing: .zero) {
+              ForEach(Array(viewModel.state.products), id: \.key) { key, items in
+                Section {
+                  ForEach(items) { item in
+                    SearchListCardView(product: item)
+                  }
+                } header: {
+                  SearchHeaderView(
+                    store: key,
+                    productsCount: items.count
+                  )
+                  .padding(.horizontal, Metrics.horizontalPadding)
+                  .padding(.top, Metrics.headerTopPadding)
+                } footer: {
+                  Rectangle()
+                    .foregroundStyle(.gray050)
+                    .frame(maxWidth: .infinity, maxHeight: 10)
+                }
+              }
             }
-          } header: {
-            SearchHeaderView(
-              store: key,
-              productsCount: items.count
-            )
-            .padding(.horizontal, Metrics.horizontalPadding)
-            .padding(.top, Metrics.headerTopPadding)
-          } footer: {
-            Rectangle()
-              .foregroundStyle(.gray050)
-              .frame(maxWidth: .infinity, maxHeight: 10)
           }
         }
+        .scrollIndicators(.hidden)
       }
     }
-    .scrollIndicators(.hidden)
     .toolbar {
       ToolbarItem(placement: .principal) {
         SearchTextField<ViewModel>()

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
@@ -25,8 +25,8 @@ struct SearchView<ViewModel>: View where ViewModel: SearchViewModelRepresentable
         Image.faceCrying
           .resizable()
           .renderingMode(.template)
+          .frame(width: Metrics.noSearchImageSize, height: Metrics.noSearchImageSize)
           .foregroundStyle(.gray400)
-          .frame(width: 56, height: 56)
         Text("검색 결과가 없어요.")
           .font(.title1)
           .foregroundStyle(.gray400)
@@ -40,26 +40,23 @@ struct SearchView<ViewModel>: View where ViewModel: SearchViewModelRepresentable
         .foregroundStyle(.gray200)
       } else {
         ScrollView {
-          if viewModel.state.isNothing {
-          } else {
-            LazyVStack(spacing: .zero) {
-              ForEach(Array(viewModel.state.products), id: \.key) { key, items in
-                Section {
-                  ForEach(items) { item in
-                    SearchListCardView(product: item)
-                  }
-                } header: {
-                  SearchHeaderView(
-                    store: key,
-                    productsCount: items.count
-                  )
-                  .padding(.horizontal, Metrics.horizontalPadding)
-                  .padding(.top, Metrics.headerTopPadding)
-                } footer: {
-                  Rectangle()
-                    .foregroundStyle(.gray050)
-                    .frame(maxWidth: .infinity, maxHeight: 10)
+          LazyVStack(spacing: .zero) {
+            ForEach(Array(viewModel.state.products), id: \.key) { key, items in
+              Section {
+                ForEach(items) { item in
+                  SearchListCardView(product: item)
                 }
+              } header: {
+                SearchHeaderView(
+                  store: key,
+                  productsCount: items.count
+                )
+                .padding(.horizontal, Metrics.horizontalPadding)
+                .padding(.top, Metrics.headerTopPadding)
+              } footer: {
+                Rectangle()
+                  .foregroundStyle(.gray050)
+                  .frame(maxWidth: .infinity, maxHeight: 10)
               }
             }
           }
@@ -85,7 +82,7 @@ private struct SearchTextField<ViewModel>: View where ViewModel: SearchViewModel
 
   var body: some View {
     ZStack {
-      TextField(Metrics.placeholder, text: $text)
+      TextField("검색할 상품이름을 입력해주세요", text: $text)
         .font(.b1)
         .frame(maxWidth: .infinity, maxHeight: Metrics.textFieldHeight)
         .padding(.vertical, Metrics.textFieldVerticalPadding)
@@ -149,8 +146,6 @@ private struct SearchHeaderView: View {
 // MARK: - Metrics
 
 private enum Metrics {
-  static let placeholder = "검색할 상품이름을 입력해주세요"
-
   static let textFieldVerticalPadding = 8.0
   static let textFieldLeadingPadding = 12.0
   static let textFieldTrailingPadding = 40.0

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchViewModel.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchViewModel.swift
@@ -28,6 +28,7 @@ struct SearchState {
 
 // MARK: - SearchViewModelRepresentable
 
+@MainActor
 protocol SearchViewModelRepresentable: ObservableObject {
   var state: SearchState { get }
   func trigger(_ action: SearchAction)
@@ -59,7 +60,6 @@ final class SearchViewModel: SearchViewModelRepresentable {
     }
   }
 
-  @MainActor
   private func handle(_ action: SearchAction) async {
     // 비동기 함수를 실행합니다. 만약 오류가 발생하면 Log로 값을 확인할 수 있습니다.
     func performAsyncAction(_ action: () async throws -> Void) async {
@@ -80,7 +80,6 @@ final class SearchViewModel: SearchViewModelRepresentable {
     }
   }
 
-  @MainActor
   private func fetchSearchList() async throws {
     let request = SearchProductRequest(
       name: state.currentText,

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchViewModel.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchViewModel.swift
@@ -14,7 +14,6 @@ import SearchAPI
 
 enum SearchAction {
   case textChanged(String)
-  case loadMoreProducts
 }
 
 // MARK: - SearchState
@@ -24,11 +23,7 @@ struct SearchState {
   var products = [ConvenienceStore: [SearchProduct]]()
   var offset = 0
   var hasMore = false
-
-  /// 화면 중앙에 표시되는 로딩 인디케이터
-  var isLoading = false
-  /// 리스트 맨 하단에 표시되는 로딩 인디케이터
-  var isMoreLoading = false
+  var isNothing = false
 }
 
 // MARK: - SearchViewModelRepresentable
@@ -64,6 +59,7 @@ final class SearchViewModel: SearchViewModelRepresentable {
     }
   }
 
+  @MainActor
   private func handle(_ action: SearchAction) async {
     // 비동기 함수를 실행합니다. 만약 오류가 발생하면 Log로 값을 확인할 수 있습니다.
     func performAsyncAction(_ action: () async throws -> Void) async {
@@ -79,33 +75,25 @@ final class SearchViewModel: SearchViewModelRepresentable {
       state.currentText = text
       state.offset = 0
       await performAsyncAction {
-        try await fetchSearchList(isReplace: true)
-      }
-
-    case .loadMoreProducts:
-      await performAsyncAction {
-        try await fetchSearchList(isReplace: false)
+        try await fetchSearchList()
       }
     }
   }
 
-  private func fetchSearchList(isReplace: Bool) async throws {
+  @MainActor
+  private func fetchSearchList() async throws {
     let request = SearchProductRequest(
       name: state.currentText,
       order: .normal,
-      pageSize: 20,
+      pageSize: 50,
       offset: state.offset
     )
 
     let paginatedModel = try await service.fetchSearchList(request: request)
-
+    let results = Dictionary(grouping: paginatedModel.results, by: { $0.convenienceStore })
     state.hasMore = paginatedModel.hasMore
     state.offset += 1
-
-    let results = Dictionary(grouping: paginatedModel.results, by: { $0.convenienceStore })
-
-    if isReplace {
-      state.products = results
-    }
+    state.products = results
+    state.isNothing = results.isEmpty
   }
 }


### PR DESCRIPTION
## Screenshots 📸

|검색실패UI|
|:-:|
|<img width="550" alt="Screenshot 2024-03-08 at 17 20 52" src="https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/97531269/a69bfb67-3155-432b-bd34-b27be313b977">|

https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/97531269/3aa0eb54-392d-4f90-a1a0-4a3803c29418


## 고민, 과정, 근거 💬

## 구현 목록
- 검색 실패 UI 구현
- String값 Localizable등록
- ViewModel trigger관련 메인스레드에서 실행되어야 하는 작업이 백그라운드 스레드에서 실행되는 이슈 해결

> 무한 스크롤 관련해서는 나중에 디자이너 분이 결정하시면 그때 바꾸는 게 나을 것 같네요!
일단은 무한 스크롤이 되지 않게 만들었습니다.

지금 검색결과를 섹션과 아이템 값을 딕셔너리로 표현해주고 있는데,
더 나은 방법이 있다면 공유 부탁드립니다.. 아직 고민 중이네요 ㅎㅎ 

<br/><br/>

## References 📋


<br/><br/>

---

- Closed: #91 
