### PR TITLE
홈 화면에서 디테일 화면으로 이동 / http 이미지 로드 지원

### DIFF
--- a/PyeonHaeng-iOS/Resources/Info.plist
+++ b/PyeonHaeng-iOS/Resources/Info.plist
@@ -4,5 +4,10 @@
 <dict>
 	<key>BaseURL</key>
 	<string>$(BASE_URL)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductListView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductListView.swift
@@ -13,31 +13,43 @@ import SwiftUI
 
 struct HomeProductListView<ViewModel>: View where ViewModel: HomeViewModelRepresentable {
   @EnvironmentObject var viewModel: ViewModel
+  @Environment(\.injected) private var container
 
   var body: some View {
-    ScrollView {
-      LazyVStack {
-        Spacer()
-          .frame(height: 96)
-        ForEach(viewModel.state.products) { item in
+    List {
+      Spacer()
+        .frame(height: 96)
+        .listRowSeparator(.hidden)
+
+      ForEach(viewModel.state.products) { item in
+        ZStack(alignment: .leading) {
+          NavigationLink {
+            ProductInfoView(viewModel: ProductInfoViewModel(service: container.services.productInfoService, productID: item.id))
+              .toolbarRole(.editor)
+          } label: {
+            EmptyView()
+          }
+          .opacity(0)
+
           ProductRow(product: item)
-            .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
-          Divider()
-        }
-        switch viewModel.state.productConfiguration.loadingState {
-        case .idle,
-             .isLoading:
-          ProgressView()
-            .progressViewStyle(.circular)
-            .frame(maxWidth: .infinity)
-            .onAppear {
-              viewModel.trigger(.loadMoreProducts)
-            }
-        case .loadedAll:
-          EmptyView()
         }
       }
+      .listRowInsets(.init())
+
+      switch viewModel.state.productConfiguration.loadingState {
+      case .idle,
+           .isLoading:
+        ProgressView()
+          .progressViewStyle(.circular)
+          .frame(maxWidth: .infinity)
+          .onAppear {
+            viewModel.trigger(.loadMoreProducts)
+          }
+      case .loadedAll:
+        EmptyView()
+      }
     }
+    .listStyle(.plain)
     .scrollIndicators(.hidden)
   }
 }


### PR DESCRIPTION
## Screenshots 📸

https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/d10743b3-a975-4fb5-860a-aeb355d6957c


## 고민, 과정, 근거 💬


- `ScrollView`에서 `List`로 변경하여 제품 상세 정보 페이지로 넘어갈 수 있도록 구현했습니다.
- 그 밖에 미비된 UI 값들을 설정했습니다.
- CU의 이미지 데이터가 `http`로 되어있어, xcodeproject에서 http를 허용시켰습니다.

---

- Closed: #111
