### PR TITLE
미비된 UI 수정(검색 시 제품 리스트 화면을 홈과 맞춤 / 제품 가격 이력 확인 시 햅틱 피드백 제공 / etc)

### DIFF
--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductListView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductListView.swift
@@ -136,6 +136,7 @@ private struct ProductDetailsView: View {
         PromotionTagView(promotion: product.promotion)
         Text(verbatim: product.name)
           .font(.title1)
+          .foregroundStyle(.gray900)
       }
       PriceView(product: product)
     }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductListView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductListView.swift
@@ -156,7 +156,7 @@ private struct PriceView: View {
       Spacer()
       Text("(\((product.price / 2).formatted())₩ per piece)")
         .font(.x2)
-        .foregroundColor(.gray100)
+        .foregroundColor(.gray300)
       HStack(spacing: 4) {
         Text("\(product.price.formatted())₩")
           .font(.h4)

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoLineGraphView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoLineGraphView.swift
@@ -49,6 +49,9 @@ struct ProductInfoLineGraphView<ViewModel>: View where ViewModel: ProductInfoVie
           index = viewModel.state.previousProducts.count - 1
         }
         .gesture(DragGesture().onChanged { viewDidDrag($0) })
+        .sensoryFeedback(trigger: offset) { _, _ in
+          .impact()
+        }
         .overlay(alignment: .bottomLeading) {
           LineGraphPanelView(
             position: (offset, index),

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchListCardView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchListCardView.swift
@@ -45,6 +45,7 @@ private struct SearchImageView: View {
         ProgressView()
       }
     }
+    .accessibilityHidden(true)
     .frame(width: Metrics.totalImageSize, height: Metrics.totalImageSize)
   }
 }
@@ -62,17 +63,17 @@ private struct SearchDetailView: View {
         .foregroundStyle(.gray900)
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.bottom, Metrics.detailVStackSpacing)
-      HStack {
-        Text("\(product.price.formatted())원")
+      HStack(spacing: 10) {
+        Spacer()
+        Text("(\((product.price / 2).formatted())₩ per piece)")
           .font(.x2)
-          .strikethrough()
-          .foregroundColor(.gray100)
-        Text("개당")
-          .font(.c3)
-          .foregroundColor(.gray900)
-        Text("\(Int(product.price / 2).formatted())원")
-          .font(.h4)
-          .foregroundColor(.gray900)
+          .foregroundColor(.gray300)
+        HStack(spacing: 4) {
+          Text("\(product.price.formatted())₩")
+            .font(.h4)
+            .accessibilityHint("기존 가격")
+            .foregroundStyle(.gray900)
+        }
       }
       .frame(maxWidth: .infinity, alignment: .trailing)
     }


### PR DESCRIPTION
## Screenshots 📸

|시연 영상|
|:-:|
|![RPReplay_Final1711030075](https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/57972338/200dbfa5-9215-46ef-91fa-6857160fe540)|

<br/><br/>

## 고민, 과정, 근거 💬

- Home화면에서  gray100을 gray300으로 수정
- 제품 가격 이력 확인할 때 햅틱 피드백 전달
- 검색 화면에서 보이는 ListView 디자인 수정 (Home 디자인에 맞춤)

---

- Closed: #117
