### PR TITLE
검색 화면 네비게이션 백 스와이프 활성화 및 미비된 UI 수정

### DIFF
--- a/APIService/Sources/ProductInfoAPI/Responses/ProductDetailResponse.swift
+++ b/APIService/Sources/ProductInfoAPI/Responses/ProductDetailResponse.swift
@@ -19,7 +19,7 @@ struct ProductDetailResponse: Decodable {
 
 struct ProductDetailItemResponse: Decodable {
   let name: String
-  let img: URL
+  let img: URL?
   let price: Int
   let store: ConvenienceStore
   let tag: Promotion

--- a/PyeonHaeng-iOS.xcodeproj/xcshareddata/xcschemes/PyeonHaeng-iOS.xcscheme
+++ b/PyeonHaeng-iOS.xcodeproj/xcshareddata/xcschemes/PyeonHaeng-iOS.xcscheme
@@ -46,6 +46,7 @@
       buildConfiguration = "Staging"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "ko"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -62,6 +63,10 @@
             ReferencedContainer = "container:PyeonHaeng-iOS.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <LocationScenarioReference
+         identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+         referenceType = "1">
+      </LocationScenarioReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/PyeonHaeng-iOS/Resources/Localizable.xcstrings
+++ b/PyeonHaeng-iOS/Resources/Localizable.xcstrings
@@ -89,7 +89,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "검색어의 단어수를 줄이거나,"
+            "value" : "• 검색어의 단어수를 줄이거나,"
           }
         }
       }
@@ -111,7 +111,7 @@
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "단어의 철자가 정확한지 확인해보세요."
+            "value" : "• 단어의 철자가 정확한지 확인해보세요."
           }
         }
       }

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductListView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductListView.swift
@@ -98,16 +98,13 @@ private struct ProductImageView: View {
           .scaledToFit()
           .frame(width: Metrics.originalImageSize, height: Metrics.originalImageSize)
           .padding(.all, (Metrics.totalImageSize - Metrics.originalImageSize) * 0.5)
-      } else if phase.error != nil {
+      } else {
         Image.textLogo
           .resizable()
           .scaledToFit()
           .frame(width: Metrics.textLogoWidth, height: Metrics.textLogoHeight)
           .padding(.horizontal, (Metrics.totalImageSize - Metrics.textLogoWidth) / 2)
           .padding(.vertical, (Metrics.totalImageSize - Metrics.textLogoHeight) / 2)
-      } else {
-        ProgressView()
-          .frame(width: Metrics.totalImageSize, height: Metrics.totalImageSize)
       }
     }
     .accessibilityHidden(true)

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
@@ -34,8 +34,10 @@ private struct ImageView: View {
         .resizable()
         .scaledToFit()
     } placeholder: {
-      // TODO: 편행 기본 이미지 추가
-      ProgressView()
+      Image.textLogo
+        .resizable()
+        .scaledToFit()
+        .padding(100)
     }
     .frame(maxWidth: .infinity, maxHeight: Metrics.imageHeight)
     .padding(.top, Metrics.imagePaddingTop)

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
@@ -63,12 +63,21 @@ private struct DetailView: View {
       }
       Spacer()
       HStack(spacing: Metrics.horizontalSpacing) {
-        PromotionTagView(promotionTag: promotionTag(for: product.promotion))
-        Text("개당")
-          .font(.c1)
-        Text("\(Int(product.price / 2).formatted())원")
-          .font(.h2)
-          .frame(maxHeight: 38.0)
+        Group {
+          PromotionTagView(promotionTag: promotionTag(for: product.promotion))
+          Text("개당")
+            .font(.c1)
+        }
+        .padding(.bottom, -12)
+        VStack(alignment: .trailing, spacing: .zero) {
+          Text("\(product.price.formatted())원")
+            .font(.x2)
+            .foregroundStyle(.gray100)
+            .strikethrough(color: .gray100)
+            .padding(.bottom, -4)
+          Text("\(Int(product.price / 2).formatted())원")
+            .font(.h2)
+        }
       }
       .frame(maxWidth: .infinity, alignment: .trailing)
     }

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoLineGraphView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoLineGraphView.swift
@@ -161,7 +161,7 @@ private struct LineGraphPanelView: View {
       Text(verbatim: "\(formatted(product.date))")
         .font(.c4)
         .foregroundStyle(.gray400)
-      Text("\((product.price / 2).formatted())원")
+      Text("\(product.price.formatted())원")
         .font(.b1)
         .foregroundStyle(.gray900)
       Rectangle()

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoView.swift
@@ -28,12 +28,12 @@ struct ProductInfoView<ViewModel>: View where ViewModel: ProductInfoViewModelRep
           ProductInfoLineGraphView<ViewModel>()
           Spacer()
         }
-      }      
+      }
+      .padding(.horizontal, 20.0)
     }
     .environmentObject(viewModel)
     .navigationTitle("제품 상세")
     .navigationBarTitleDisplayMode(.inline)
-    .padding(.horizontal, 20.0)
     .onAppear {
       viewModel.trigger(.fetchProduct)
     }

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoView.swift
@@ -18,15 +18,17 @@ struct ProductInfoView<ViewModel>: View where ViewModel: ProductInfoViewModelRep
   }
 
   var body: some View {
-    VStack {
-      if viewModel.state.isLoading {
-        ProgressView()
-          .containerRelativeFrame(.vertical)
-      } else {
-        ProductInfoDetailView<ViewModel>()
-        ProductInfoLineGraphView<ViewModel>()
-        Spacer()
-      }
+    ScrollView {
+      VStack {
+        if viewModel.state.isLoading {
+          ProgressView()
+            .containerRelativeFrame(.vertical)
+        } else {
+          ProductInfoDetailView<ViewModel>()
+          ProductInfoLineGraphView<ViewModel>()
+          Spacer()
+        }
+      }      
     }
     .environmentObject(viewModel)
     .navigationTitle("제품 상세")

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
@@ -9,18 +9,6 @@ import DesignSystem
 import Entity
 import SwiftUI
 
-
-extension UINavigationController: ObservableObject, UIGestureRecognizerDelegate {
-  open override func viewDidLoad() {
-    super.viewDidLoad()
-    interactivePopGestureRecognizer?.delegate = self
-  }
-  
-  public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-    return viewControllers.count > 1
-  }
-}
-
 // MARK: - SearchView
 
 struct SearchView<ViewModel>: View where ViewModel: SearchViewModelRepresentable {
@@ -34,19 +22,6 @@ struct SearchView<ViewModel>: View where ViewModel: SearchViewModelRepresentable
   }
 
   var body: some View {
-    HStack(spacing: 8) {
-      Button {
-        dismiss()
-      } label: {
-        Image.chevronLeftLarge
-          .resizable()
-          .scaledToFit()
-          .frame(width: 24)
-      }
-      SearchTextField<ViewModel>(text: $text)
-        .environmentObject(viewModel)
-    }
-    .padding(.horizontal, 20)
     ScrollView {
       if viewModel.state.isLoading {
         ProgressView()
@@ -103,7 +78,11 @@ struct SearchView<ViewModel>: View where ViewModel: SearchViewModelRepresentable
         }
       }
     }
-    .toolbar(.hidden, for: .navigationBar)
+    .toolbar {
+      ToolbarItem(placement: .principal) {
+        SearchTextField<ViewModel>(text: $text)
+      }
+    }
     .scrollIndicators(.hidden)
     .scrollDismissesKeyboard(.immediately)
     .environmentObject(viewModel)
@@ -188,7 +167,7 @@ private enum Metrics {
   static let textFieldVerticalPadding = 8.0
   static let textFieldLeadingPadding = 12.0
   static let textFieldTrailingPadding = 40.0
-  static let textFieldHeight = 32.0
+  static let textFieldHeight = 24.0
   static let textFieldBorderWidth = 1.0
   static let cornerRadius = 8.0
 

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
@@ -9,6 +9,18 @@ import DesignSystem
 import Entity
 import SwiftUI
 
+
+extension UINavigationController: ObservableObject, UIGestureRecognizerDelegate {
+  open override func viewDidLoad() {
+    super.viewDidLoad()
+    interactivePopGestureRecognizer?.delegate = self
+  }
+  
+  public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+    return viewControllers.count > 1
+  }
+}
+
 // MARK: - SearchView
 
 struct SearchView<ViewModel>: View where ViewModel: SearchViewModelRepresentable {
@@ -91,7 +103,7 @@ struct SearchView<ViewModel>: View where ViewModel: SearchViewModelRepresentable
         }
       }
     }
-    .toolbar(.hidden, for: .automatic)
+    .toolbar(.hidden, for: .navigationBar)
     .scrollIndicators(.hidden)
     .scrollDismissesKeyboard(.immediately)
     .environmentObject(viewModel)


### PR DESCRIPTION
## Screenshots 📸

https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/97531269/41e25d0c-18ba-4475-9e1c-37f96d862e45

<br/><br/>

## 고민, 과정, 근거 💬

- 제품 상세 화면에 스크롤 뷰를 임베드했습니다.
- 제품 상세 화면 원가격에 취소선을 추가했습니다.
- 서버에서 불러온 상품 데이터들의 이미지 URL이 종종 null로 응답되는 경우가 있어서 이를 다음과 같이 수정했습니다.
  - 이미지URL이 null일 경우 ProgressView가 무한로딩이 되는 버그를 편행 로고 이미지로 바꾸었습니다. (홈, 검색)
  - 제품 상세 화면에서 이미지 URL이 null일 경우 아무것도 뜨지 않는 버그를 수정했습니다.
- 검색 화면에서 백 스와이프로 이전 화면으로 넘어가는 기능을 추가했습니다.
  - 이 부분은 기존 커스텀 네비게이션 바를 사용했지만, UIKit 코드를 접합시켜 백 스와이프 기능을 추가할 수 있었습니다. 하지만 많은 부분에서 버그가 발생하더군요.. ㅠㅠ 
  - 그래서 다른 방안으로 네비게이션 바를 임베드하고 깨지지 않을 정도의 높이를 가지고 텍스트 필드를 추가했습니다.

<br/><br/>

## References 📋


<br/><br/>

---

- Closed: #122 

