### PR TITLE
상품 상세 페이지 UI 버그 수정

### DIFF
--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
@@ -55,14 +55,16 @@ private struct DetailView: View {
       .font(.h3)
       .foregroundStyle(Color.gray900)
       .frame(maxWidth: .infinity, alignment: .leading)
-    HStack(alignment: .bottom) {
+    ZStack(alignment: .bottom) {
       VStack(alignment: .leading, spacing: .zero) {
         Text("행사 진행 편의점")
           .font(.c2)
           .padding(.top, Metrics.textPaddingTop)
+          .frame(maxWidth: 120, alignment: .leading)
         image(for: product.convenienceStore)
           .padding(.top, Metrics.convenienceStoreLogoPaddingTop)
       }
+      .frame(maxWidth: .infinity, alignment: .leading)
       Spacer()
       HStack(spacing: Metrics.horizontalSpacing) {
         Group {

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
@@ -68,7 +68,7 @@ private struct DetailView: View {
       Spacer()
       HStack(spacing: Metrics.horizontalSpacing) {
         PromotionTagView(promotionTag: promotionTag(for: product.promotion))
-        .padding(.bottom, -12)
+          .padding(.bottom, -12)
         VStack(alignment: .trailing, spacing: .zero) {
           Text("(\((product.price / 2).formatted())₩ per piece)")
             .font(.x2)

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
@@ -67,19 +67,15 @@ private struct DetailView: View {
       .frame(maxWidth: .infinity, alignment: .leading)
       Spacer()
       HStack(spacing: Metrics.horizontalSpacing) {
-        Group {
-          PromotionTagView(promotionTag: promotionTag(for: product.promotion))
-          Text("개당")
-            .font(.c1)
-        }
+        PromotionTagView(promotionTag: promotionTag(for: product.promotion))
         .padding(.bottom, -12)
         VStack(alignment: .trailing, spacing: .zero) {
-          Text("\(product.price.formatted())원")
+          Text("(\((product.price / 2).formatted())₩ per piece)")
             .font(.x2)
             .foregroundStyle(.gray100)
             .strikethrough(color: .gray100)
             .padding(.bottom, -4)
-          Text("\(Int(product.price / 2).formatted())원")
+          Text("\(product.price.formatted())₩")
             .font(.h2)
         }
       }

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
@@ -73,7 +73,6 @@ private struct DetailView: View {
           Text("(\((product.price / 2).formatted())₩ per piece)")
             .font(.x2)
             .foregroundStyle(.gray100)
-            .strikethrough(color: .gray100)
             .padding(.bottom, -4)
           Text("\(product.price.formatted())₩")
             .font(.h2)

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoLineGraphView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoLineGraphView.swift
@@ -162,6 +162,7 @@ private struct LineGraphPanelView: View {
         .font(.c4)
         .foregroundStyle(.gray400)
       Text("\(product.price.formatted())원")
+        .frame(maxWidth: .infinity)
         .font(.b1)
         .foregroundStyle(.gray900)
       Rectangle()
@@ -215,8 +216,8 @@ private enum Metrics {
   static let symbolWidth: CGFloat = 4.0
   static let frameHeight: CGFloat = 226.0
   static let lineGraphHeight: CGFloat = 162.0
-
-  static let panelWidth: CGFloat = 60.0
+  
+  static let panelWidth: CGFloat = 70.0
   static let panelHeight: CGFloat = 162.0
   static let panelPoleHeight: CGFloat = 122.0
 }

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoLineGraphView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoLineGraphView.swift
@@ -216,7 +216,7 @@ private enum Metrics {
   static let symbolWidth: CGFloat = 4.0
   static let frameHeight: CGFloat = 226.0
   static let lineGraphHeight: CGFloat = 162.0
-  
+
   static let panelWidth: CGFloat = 70.0
   static let panelHeight: CGFloat = 162.0
   static let panelPoleHeight: CGFloat = 122.0

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
@@ -16,11 +16,11 @@ struct SearchView<ViewModel>: View where ViewModel: SearchViewModelRepresentable
   @State private var text: String = ""
   @Environment(\.dismiss) private var dismiss
   @Environment(\.injected) private var container
-
+  
   init(viewModel: @autoclosure @escaping () -> ViewModel) {
     _viewModel = .init(wrappedValue: viewModel())
   }
-
+  
   var body: some View {
     ScrollView {
       if viewModel.state.isLoading {

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
@@ -16,11 +16,11 @@ struct SearchView<ViewModel>: View where ViewModel: SearchViewModelRepresentable
   @State private var text: String = ""
   @Environment(\.dismiss) private var dismiss
   @Environment(\.injected) private var container
-  
+
   init(viewModel: @autoclosure @escaping () -> ViewModel) {
     _viewModel = .init(wrappedValue: viewModel())
   }
-  
+
   var body: some View {
     ScrollView {
       if viewModel.state.isLoading {


### PR DESCRIPTION
## Screenshots 📸

<img width="501" alt="image" src="https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/97531269/5f46321c-0ef5-4d98-a6dc-7402fbf748c0">

<br/><br/>

## 고민, 과정, 근거 💬

- 상품의 가격이 만 원 이상이 되었을 때 텍스트가 깨지는 버그를 수정했습니다.

<br/><br/>

## References 📋


<br/><br/>

---

- Closed: #131 
