### PR TITLE
svg 파일이 png로 보이는 버그 수정

### DIFF
--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -2,9 +2,9 @@ name: iOS CI workflow
 
 on:
   push:
-    branches: ["feature/*"]
+    branches: ['**']
   pull_request:
-    branches: ["main"]
+    branches: ['**']
     types: [labeled, opened, synchronize, reopened]
 
 jobs:

--- a/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductDetailSelectionView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/HomeScene/View/HomeProductDetailSelectionView.swift
@@ -31,7 +31,7 @@ struct HomeProductDetailSelectionView<ViewModel>: View where ViewModel: HomeView
       Group {
         convenienceImageView()
           .resizable()
-          .scaledToFit()
+          .aspectRatio(contentMode: .fit)
         Image.chevronDown
           .renderingMode(.template)
           .foregroundStyle(.gray300)

--- a/Shared/Sources/DesignSystem/Resources/Images.xcassets/BrandImage/7-Eleven.imageset/Contents.json
+++ b/Shared/Sources/DesignSystem/Resources/Images.xcassets/BrandImage/7-Eleven.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Shared/Sources/DesignSystem/Resources/Images.xcassets/BrandImage/CU.imageset/Contents.json
+++ b/Shared/Sources/DesignSystem/Resources/Images.xcassets/BrandImage/CU.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Shared/Sources/DesignSystem/Resources/Images.xcassets/BrandImage/Emart24.imageset/Contents.json
+++ b/Shared/Sources/DesignSystem/Resources/Images.xcassets/BrandImage/Emart24.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Shared/Sources/DesignSystem/Resources/Images.xcassets/BrandImage/GS25.imageset/Contents.json
+++ b/Shared/Sources/DesignSystem/Resources/Images.xcassets/BrandImage/GS25.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/Shared/Sources/DesignSystem/Resources/Images.xcassets/BrandImage/Ministop.imageset/Contents.json
+++ b/Shared/Sources/DesignSystem/Resources/Images.xcassets/BrandImage/Ministop.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }


### PR DESCRIPTION
## Screenshots 📸

|버그 발견|
|:-:|
|![](https://file.notion.so/f/f/b8b821c9-13ad-4654-b758-35563b7a116b/363d2540-c590-40e4-a41c-7224ef582c3f/Screenshot_2024-03-25_at_5.36.07_PM.png?id=2916cf8f-caf4-4c21-aa8a-c491cbf9073d&table=block&spaceId=b8b821c9-13ad-4654-b758-35563b7a116b&expirationTimestamp=1711447200000&signature=XUfoQ7rhzVL_awzsdk8jKhPVcmcBlCcEYxjKibxGZFM&downloadName=Screenshot+2024-03-25+at+5.36.07%E2%80%AFPM.png)|
|수정|
|![](https://file.notion.so/f/f/b8b821c9-13ad-4654-b758-35563b7a116b/dc0d05a0-404d-4db8-aa24-f4dadde2e6cc/Untitled.png?id=260d732d-429f-403b-8f44-2c3de8fa109b&table=block&spaceId=b8b821c9-13ad-4654-b758-35563b7a116b&expirationTimestamp=1711447200000&signature=ZphITP77dlFODSAFBcNBObH8f82lchVlDCRBtO4LWAg&downloadName=Untitled.png)|


## 고민, 과정, 근거 💬

리사이징되면서 svg형식이 아니라 png방식으로 보이는 현상을 수정했습니다.

## References 📋

1. [IOS Swift SVG image quality issues when resized](https://stackoverflow.com/questions/74764061/ios-swift-svg-image-quality-issues-when-resized)

---

- Closed: #133
