### PR TITLE
제품 상세 화면 UI 개선

### DIFF
--- a/PyeonHaeng-iOS.xcodeproj/xcshareddata/xcschemes/DesignSystemApp.xcscheme
+++ b/PyeonHaeng-iOS.xcodeproj/xcshareddata/xcschemes/DesignSystemApp.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1530"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoDetailView.swift
@@ -72,7 +72,7 @@ private struct DetailView: View {
         VStack(alignment: .trailing, spacing: .zero) {
           Text("(\((product.price / 2).formatted())₩ per piece)")
             .font(.x2)
-            .foregroundStyle(.gray100)
+            .foregroundStyle(.gray300)
             .padding(.bottom, -4)
           Text("\(product.price.formatted())₩")
             .font(.h2)

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoLineGraphView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductInfoScene/ProductInfoLineGraphView.swift
@@ -166,7 +166,7 @@ private struct LineGraphPanelView: View {
         .font(.b1)
         .foregroundStyle(.gray900)
       Rectangle()
-        .foregroundStyle(.gray100)
+        .foregroundStyle(.gray300)
         .frame(width: 1.0, height: Metrics.panelPoleHeight)
     }
     .frame(width: Metrics.panelWidth, height: Metrics.panelHeight)

--- a/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
+++ b/PyeonHaeng-iOS/Sources/Scenes/ProductSearchScene/SearchView.swift
@@ -56,6 +56,7 @@ struct SearchView<ViewModel>: View where ViewModel: SearchViewModelRepresentable
                   ForEach(items) { item in
                     NavigationLink {
                       ProductInfoView(viewModel: ProductInfoViewModel(service: container.services.productInfoService, productID: item.id))
+                        .toolbarRole(.editor)
                     } label: {
                       SearchListCardView(product: item)
                     }


### PR DESCRIPTION
## Screenshots 📸

![image](https://github.com/PyeonHaeng/PyeonHaeng-iOS/assets/97531269/d7cfa3a6-910a-4cc6-aa74-a79d00e26254)

<br/><br/>

## 고민, 과정, 근거 💬

- 기존 텍스트 Gray100 색상을 Gray300 색상으로 모두 변경
- 검색화면에서 제품 상세 화면으로 넘어갈 때, 뒤로가기 텍스트 삭제

<br/><br/>

## References 📋


<br/><br/>

---

- Closed: #(issue-here)
